### PR TITLE
Force UTF-8 stdio and fix keyword substring false-positives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ## [Unreleased]
 
+### Fixed — Windows console encoding and keyword matching
+
+- All CLI/MCP entry points now force UTF-8 on stdin/stdout/stderr (`scripts/lib/stdio.py`), fixing crashes on Windows consoles using a legacy codepage (e.g. cp1252) whenever workspace content contains non-ASCII characters (Vietnamese text, arrows, etc.). Previously `contextd context`, `contextd explain`, `contextd check`, and `contextd mcp-server` could raise `UnicodeEncodeError`/`UnicodeDecodeError` mid-run.
+- `detect_intent`/`detect_workstream`/`detect_components`/`_score` in `task_context_engine.py` now match keywords on word boundaries instead of raw substrings, fixing false-positive classifications (e.g. `"api"` no longer matches inside `"rapid"`, `"ui"` no longer matches inside `"build"`, `"check"` no longer matches inside `"checkout"`). Punctuation-heavy keywords (`.proto`, `@RestController`) and multi-word/hyphenated keywords (`drift-check`) still match correctly, and Vietnamese keywords keep correct boundaries.
+- `detect_intent`/`detect_workstream` now break keyword-score ties deterministically via an explicit precedence order instead of relying on Python dict iteration order.
+- Added `intent.classification` (per-axis scores, runner-up, tie-broken flag) to the `contextd_task_context.v1` artifact and surfaced it in `contextd explain --text` output, for debugging classification decisions.
+- Added `"debug"` to the `fix_bug` intent keyword list (previously matched only by accident via the `"bug"` substring inside `"debug"`, which the word-boundary fix above no longer allows).
+
 ### Added — Production context diagnostics
 
 Added P0 production-readiness diagnostics and context quality tooling:

--- a/scripts/check-patterns-index.py
+++ b/scripts/check-patterns-index.py
@@ -25,6 +25,8 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Tuple
 
+from lib.stdio import configure_stdio
+
 REPO_ROOT = Path(__file__).resolve().parent.parent
 WORKSPACES_DIR = REPO_ROOT / "workspaces"
 
@@ -99,6 +101,7 @@ def check_workspace(ws_dir: Path, print_hints: bool) -> int:
 
 
 def main() -> None:
+    configure_stdio()
     ap = argparse.ArgumentParser(description=__doc__.splitlines()[1])
     ap.add_argument("--workspace", help="Check only this workspace")
     ap.add_argument("--fix-hint", action="store_true",

--- a/scripts/cli.py
+++ b/scripts/cli.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 from contextd_version import get_version  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 __version__ = get_version(start_path=SCRIPT_DIR.parent)
 
@@ -604,6 +605,7 @@ def _mcp_config_cmd(args) -> int:
 
 
 def main() -> int:
+    configure_stdio()
     raw_args = sys.argv[1:]
     if not raw_args or raw_args in (["--help"], ["-h"]):
         print(_render_starter_help(), end="")

--- a/scripts/cmd_bundle.py
+++ b/scripts/cmd_bundle.py
@@ -18,6 +18,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR))
 
 import cmd_resolve  # noqa: E402
+from lib.stdio import configure_stdio  # noqa: E402
 
 
 def _collect_workspace_files(ws_dir: Path) -> List[Path]:
@@ -172,6 +173,7 @@ def bundle(
 
 
 def main():
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Bundle workspace knowledge into a single markdown file.")
     parser.add_argument("--workspace", default=None, help="Workspace name (default: resolved)")

--- a/scripts/cmd_contract_path.py
+++ b/scripts/cmd_contract_path.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 import cmd_resolve  # noqa: E402
 import task_context_engine  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 
 def run(contract_id: str, workspace: str | None = None,
@@ -54,6 +55,7 @@ def run(contract_id: str, workspace: str | None = None,
 
 
 def main():
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Resolve a contextd contract id.")
     parser.add_argument("contract_id", help="Contract id, e.g. citation-format")

--- a/scripts/cmd_doctor.py
+++ b/scripts/cmd_doctor.py
@@ -19,6 +19,7 @@ import pack_validation  # noqa: E402
 import render_runtime  # noqa: E402
 import task_context_engine  # noqa: E402
 from context_security import block_reason, reject_unsafe_entry  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 
 Issue = Dict[str, str]
@@ -320,6 +321,7 @@ def run(cwd: str | None = None, fmt: str = "json") -> int:
 
 
 def main() -> None:
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Diagnose contextd production-readiness issues.")
     parser.add_argument("--cwd", default=None, help="Start directory (default: current)")

--- a/scripts/cmd_eval.py
+++ b/scripts/cmd_eval.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 import cmd_resolve  # noqa: E402
 import task_context_engine  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 
 def _load_fixture(path: Path) -> Dict | None:
@@ -176,6 +177,7 @@ def run(golden: bool = False, workspace: str | None = None, fmt: str = "json",
 
 
 def main() -> None:
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Evaluate contextd context selection.")
     parser.add_argument("--golden", action="store_true", help="Run golden task fixtures")

--- a/scripts/cmd_explain.py
+++ b/scripts/cmd_explain.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 import cmd_resolve  # noqa: E402
 import task_context_engine  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 
 def _render_text(payload: dict) -> str:
@@ -25,6 +26,15 @@ def _render_text(payload: dict) -> str:
         "",
         f"Workspace: {summary['workspace']}",
         f"Intent: {summary['intent'].get('type')} / {summary['intent'].get('workstream')}",
+    ]
+    classification = summary["intent"].get("classification") or {}
+    for axis in ("intent", "workstream"):
+        info = classification.get(axis) or {}
+        if info.get("scores"):
+            scores_str = ", ".join(f"{k}={v}" for k, v in info["scores"].items())
+            tie_note = " (tie-broken by precedence)" if info.get("tie_broken") else ""
+            lines.append(f"  {axis} scores: {scores_str}{tie_note}")
+    lines += [
         f"Context Pack: {summary['context_pack_key']}",
         (
             "Budget: "
@@ -128,6 +138,7 @@ def run(
 
 
 def main() -> None:
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Explain deterministic context selection.")
     parser.add_argument("task", help="Task description (quote if multi-word)")

--- a/scripts/cmd_find.py
+++ b/scripts/cmd_find.py
@@ -18,6 +18,7 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 import cmd_resolve  # noqa: E402
 import find_engine  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 
 def run(query: str, workspace: str | None = None, limit: int = 5, fmt: str = "text") -> int:
@@ -74,6 +75,7 @@ def run(query: str, workspace: str | None = None, limit: int = 5, fmt: str = "te
 
 
 def main():
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Fuzzy search across contextd workspace knowledge.")
     parser.add_argument("query", help="Search keywords")

--- a/scripts/cmd_mcp_config.py
+++ b/scripts/cmd_mcp_config.py
@@ -10,6 +10,11 @@ import sys
 from pathlib import Path
 from typing import Dict, List, Optional
 
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from lib.stdio import configure_stdio  # noqa: E402
+
 
 VALID_CLIENTS = {"claude", "cursor", "codex", "all"}
 
@@ -92,6 +97,7 @@ def run(client: str, knowledge_root: str, workspace: Optional[str] = None,
 
 
 def main() -> None:
+    configure_stdio()
     parser = argparse.ArgumentParser(description="Print contextd MCP client snippets.")
     parser.add_argument("--client", required=True, choices=sorted(VALID_CLIENTS),
                         help="Client snippet to print")

--- a/scripts/cmd_migrate_config.py
+++ b/scripts/cmd_migrate_config.py
@@ -12,6 +12,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 import contextd_resolver  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 
 def run(cwd: str | None = None, force: bool = False,
@@ -61,6 +62,7 @@ def run(cwd: str | None = None, force: bool = False,
 
 
 def main():
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Migrate legacy config to .contextd/config.json.")
     parser.add_argument("--cwd", default=None, help="Start directory (default: current)")

--- a/scripts/cmd_pack_validate.py
+++ b/scripts/cmd_pack_validate.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 import cmd_resolve  # noqa: E402
 import pack_validation  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 
 def _render_text(report: dict) -> str:
@@ -65,6 +66,7 @@ def run(all_packs: bool = False, pack: str | None = None, fmt: str = "json",
 
 
 def main() -> None:
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Validate contextd packs and retrieval maps.")
     group = parser.add_mutually_exclusive_group()

--- a/scripts/cmd_policy_check.py
+++ b/scripts/cmd_policy_check.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 import cmd_resolve  # noqa: E402
 import task_context_engine  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 
 def _render_text(report: dict) -> str:
@@ -107,6 +108,7 @@ def run(task: str, workspace: str | None = None, cwd: str | None = None,
 
 
 def main() -> None:
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Evaluate contextd policy-as-code for a task.")
     parser.add_argument("task", help="Task description (quote if multi-word)")

--- a/scripts/cmd_resolve.py
+++ b/scripts/cmd_resolve.py
@@ -17,6 +17,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 import contextd_resolver  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 
 def find_wiki_json(start_dir: Path) -> Optional[Path]:
@@ -45,6 +46,7 @@ def resolve(cwd: Optional[Path] = None, require_workspace: bool = False) -> Dict
 
 
 def main():
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Resolve contextd workspace context.")
     parser.add_argument("--cwd", default=None, help="Start directory (default: .)")

--- a/scripts/cmd_task_context.py
+++ b/scripts/cmd_task_context.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 import cmd_resolve  # noqa: E402
 import task_context_engine  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 
 def run(
@@ -84,6 +85,7 @@ def run(
 
 
 def main():
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Build deterministic task context.")
     parser.add_argument("task", help="Task description (quote if multi-word)")

--- a/scripts/detect_repetition.py
+++ b/scripts/detect_repetition.py
@@ -31,6 +31,7 @@ from lib.atomic_write import (  # noqa: E402
     with_advisory_lock,
 )
 from lib import contextd_resolver  # noqa: E402
+from lib.stdio import configure_stdio  # noqa: E402
 from lib.repetition import (  # noqa: E402
     MIN_PROMPT_TOKENS,
     Cluster,
@@ -262,6 +263,7 @@ def emit_hint(text: str) -> None:
 # ---------------------------------------------------------------------------
 
 def main() -> int:
+    configure_stdio()
     started_ms = time.monotonic() * 1000.0
 
     raw = sys.stdin.read()

--- a/scripts/emit_trace.py
+++ b/scripts/emit_trace.py
@@ -31,6 +31,7 @@ from lib.atomic_write import (  # noqa: E402
     atomic_write_json,
     with_advisory_lock,
 )
+from lib.stdio import configure_stdio  # noqa: E402
 
 ALLOWED_SUBAGENTS = {
     "contextd-planner",
@@ -136,6 +137,7 @@ def stage_to_filename(stage: str) -> str:
 
 
 def main() -> int:
+    configure_stdio()
     raw = sys.stdin.read()
     if not raw.strip():
         return 0

--- a/scripts/generate_manifest.py
+++ b/scripts/generate_manifest.py
@@ -24,6 +24,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 REPO_ROOT = SCRIPT_DIR.parent
 sys.path.insert(0, str(SCRIPT_DIR))
 import pack_loader  # noqa: E402
+from lib.stdio import configure_stdio  # noqa: E402
 
 
 def _parse_frontmatter(text: str) -> Optional[Dict[str, str]]:
@@ -234,6 +235,7 @@ def write_manifest(manifest: Dict, output_path: Optional[Path] = None) -> Path:
 
 
 def main():
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Generate contextd manifest index.")
     parser.add_argument("--output", default=None, help="Output path (default: .contextd/manifest.json)")

--- a/scripts/install-to-claude.py
+++ b/scripts/install-to-claude.py
@@ -17,6 +17,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from lib.stdio import configure_stdio
+
 
 def resolve_dir(raw: Optional[str], default: Path) -> Path:
     if not raw:
@@ -192,6 +194,7 @@ def print_mcp_config(engine_root: Path, client: str, knowledge_root: Path,
 
 
 def main() -> None:
+    configure_stdio()
     parser = argparse.ArgumentParser(description="Install contextd Claude adapter files.")
     parser.add_argument("engine_root", nargs="?", default=None,
                         help="Path to contextd engine repo")

--- a/scripts/lib/stdio.py
+++ b/scripts/lib/stdio.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Force UTF-8 stdio so CLI/MCP output survives legacy console codepages.
+
+Windows terminals commonly default `sys.stdout`/`sys.stdin` to a legacy
+codepage (e.g. cp1252), which raises UnicodeEncodeError/UnicodeDecodeError
+as soon as workspace content contains non-ASCII characters (Vietnamese
+text, arrows, etc. are common throughout this repo's knowledge base).
+
+Call `configure_stdio()` first thing in every script entry point.
+"""
+
+from __future__ import annotations
+
+import sys
+
+
+def configure_stdio(errors: str = "replace") -> None:
+    """Reconfigure stdin/stdout/stderr to UTF-8 where possible.
+
+    No-op for streams that don't support `reconfigure` (e.g. io.StringIO
+    used by tests via contextlib.redirect_stdout) so tests keep working
+    unchanged.
+    """
+    for stream in (sys.stdin, sys.stdout, sys.stderr):
+        reconfigure = getattr(stream, "reconfigure", None)
+        if reconfigure is None:
+            continue
+        try:
+            reconfigure(encoding="utf-8", errors=errors)
+        except (ValueError, OSError):
+            pass
+
+
+__all__ = ["configure_stdio"]

--- a/scripts/lib/task_context_engine.py
+++ b/scripts/lib/task_context_engine.py
@@ -27,7 +27,7 @@ INTENT_KEYWORDS = {
         "producer", "service", "handler", "controller",
     ],
     "fix_bug": [
-        "fix", "bug", "broken", "breaks", "error", "crash", "fails", "failing",
+        "fix", "bug", "debug", "broken", "breaks", "error", "crash", "fails", "failing",
         "not working", "doesn't work", "exception", "regression", "issue",
     ],
     "design": [
@@ -288,6 +288,15 @@ WORKSTREAM_PRIORITY = {
     },
 }
 
+# Deterministic tie-break order for detect_intent()/detect_workstream() when
+# keyword scores are equal. Most specific/urgent first; generic fallback
+# values (implement_feature, engineering) last so they only win by default.
+INTENT_PRECEDENCE = ["incident", "fix_bug", "review", "design", "implement_feature"]
+WORKSTREAM_PRECEDENCE = [
+    "security", "ops", "quality", "business_analysis",
+    "product", "design", "domain_research", "engineering",
+]
+
 
 def _now() -> str:
     return datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -316,16 +325,73 @@ def _rel(path: Path, root: Path) -> str:
         return path.as_posix()
 
 
-def detect_intent(task: str) -> str:
-    task_lower = task.lower()
+_KEYWORD_PATTERN_CACHE: Dict[str, "re.Pattern"] = {}
+
+
+def _keyword_pattern(keyword: str) -> "re.Pattern":
+    """Compile (and cache) a word-boundary-aware pattern for `keyword`.
+
+    Boundaries are added only where the keyword's edge character is itself
+    a word character. This keeps substring-only keywords like `.proto` or
+    `@RestController` matching (they'd never match with hard `\\b` anchors)
+    while stopping plain-word keywords like `api`/`ui`/`check` from matching
+    inside unrelated words (`rapid`, `build`, `checkout`). `\\w` is
+    unicode-aware, so Vietnamese keywords (e.g. "đánh giá") keep correct
+    boundaries too. Multi-word keywords also match hyphen/underscore/slash
+    joins, e.g. "drift check" matches "drift-check".
+    """
+    pattern = _KEYWORD_PATTERN_CACHE.get(keyword)
+    if pattern is None:
+        tokens = keyword.split()
+        body = r"[\s\-_/]+".join(re.escape(tok) for tok in tokens)
+        prefix = r"(?<!\w)" if keyword[:1].isalnum() or keyword[:1] == "_" else ""
+        suffix = r"(?!\w)" if keyword[-1:].isalnum() or keyword[-1:] == "_" else ""
+        pattern = re.compile(prefix + body + suffix, re.IGNORECASE)
+        _KEYWORD_PATTERN_CACHE[keyword] = pattern
+    return pattern
+
+
+def _matches(keyword: str, text: str) -> bool:
+    return bool(keyword) and _keyword_pattern(keyword).search(text) is not None
+
+
+def _pick_by_precedence(scores: Dict[str, int], precedence: List[str],
+                        default: str) -> str:
+    """Pick the highest-scoring key; ties broken by `precedence` order."""
+    if not scores:
+        return default
+    order = {name: idx for idx, name in enumerate(precedence)}
+    fallback_rank = len(precedence)
+    return max(
+        scores,
+        key=lambda name: (scores[name], -order.get(name, fallback_rank)),
+    )
+
+
+def _classification_summary(scores: Dict[str, int], chosen: str) -> Dict:
+    """Expose why `chosen` won, for `contextd explain` debugging."""
+    ranked = sorted(scores.items(), key=lambda item: -item[1])
+    top_score = scores.get(chosen)
+    tie_broken = sum(1 for _, score in ranked if score == top_score) > 1
+    runner_up = next((name for name, _ in ranked if name != chosen), None)
+    return {
+        "scores": dict(sorted(scores.items())),
+        "runner_up": runner_up,
+        "tie_broken": tie_broken,
+    }
+
+
+def _intent_scores(task: str) -> Dict[str, int]:
     scores: Dict[str, int] = {}
     for intent, keywords in INTENT_KEYWORDS.items():
-        score = sum(1 for kw in keywords if kw in task_lower)
+        score = sum(1 for kw in keywords if _matches(kw, task))
         if score:
             scores[intent] = score
-    if not scores:
-        return "implement_feature"
-    return max(scores, key=scores.get)
+    return scores
+
+
+def detect_intent(task: str) -> str:
+    return _pick_by_precedence(_intent_scores(task), INTENT_PRECEDENCE, "implement_feature")
 
 
 def _parse_pack_keywords(pack_yaml: Path) -> Dict[str, List[str]]:
@@ -351,19 +417,17 @@ def _parse_pack_keywords(pack_yaml: Path) -> Dict[str, List[str]]:
 
 
 def detect_components(task: str, wiki_root: Path, packs: List[str]) -> List[str]:
-    task_lower = task.lower()
     components: set[str] = set()
     for pack_name in packs:
         keywords = _parse_pack_keywords(wiki_root / "packs" / pack_name / "pack.yaml")
         for component, words in keywords.items():
-            if any(word.lower() in task_lower for word in words):
+            if any(_matches(word, task) for word in words):
                 components.add(component)
     return sorted(components)
 
 
 def detect_scope(task: str, wiki_root: Path, workspace: str) -> Tuple[Optional[str], Optional[str]]:
     """Detect domain + project by matching directory names in task text."""
-    task_lower = task.lower()
     ws_dir = wiki_root / "workspaces" / workspace
 
     def match_dir(parent: Path) -> Optional[str]:
@@ -372,18 +436,17 @@ def detect_scope(task: str, wiki_root: Path, workspace: str) -> Tuple[Optional[s
         for path in sorted(p for p in parent.iterdir() if p.is_dir()):
             name = path.name.lower()
             variants = {name, name.replace("-", " "), name.replace("_", " ")}
-            if any(v and v in task_lower for v in variants):
+            if any(v and _matches(v, task) for v in variants):
                 return path.name
         return None
 
     return match_dir(ws_dir / "domains"), match_dir(ws_dir / "projects")
 
 
-def detect_workstream(task: str, packs: List[str], components: List[str]) -> str:
-    task_lower = task.lower()
+def _workstream_scores(task: str, packs: List[str], components: List[str]) -> Dict[str, int]:
     scores: Dict[str, int] = {}
     for workstream, keywords in WORKSTREAM_KEYWORDS.items():
-        score = sum(1 for kw in keywords if kw in task_lower)
+        score = sum(1 for kw in keywords if _matches(kw, task))
         if score:
             scores[workstream] = scores.get(workstream, 0) + score
 
@@ -396,9 +459,12 @@ def detect_workstream(task: str, packs: List[str], components: List[str]) -> str
         else:
             scores[workstream] = scores.get(workstream, 0) + 1
 
-    if not scores:
-        return "engineering"
-    return max(scores, key=scores.get)
+    return scores
+
+
+def detect_workstream(task: str, packs: List[str], components: List[str]) -> str:
+    scores = _workstream_scores(task, packs, components)
+    return _pick_by_precedence(scores, WORKSTREAM_PRECEDENCE, "engineering")
 
 
 def _strip_inline_note(value: str) -> str:
@@ -776,7 +842,7 @@ def _collect_candidates(
 
 
 def _keywords(task: str, components: List[str]) -> List[str]:
-    raw = re.findall(r"[A-Za-z0-9_\-]{3,}", task.lower())
+    raw = re.findall(r"[^\W_][\w\-]{2,}", task.lower(), flags=re.UNICODE)
     stop = {
         "the", "and", "for", "with", "this", "that", "into", "from", "contextd",
         "implement", "create", "build", "design", "review",
@@ -790,11 +856,11 @@ def _score(doc: Dict, words: List[str]) -> int:
     name = Path(doc["path"]).stem.lower()
     score = 0
     for word in words:
-        if word in name:
+        if _matches(word, name):
             score += 10
-        if word in text[:800]:
+        if _matches(word, text[:800]):
             score += 3
-        elif word in text:
+        elif _matches(word, text):
             score += 1
     score += max(0, 5 - PRIORITY.get(doc["category"], 5))
     return score
@@ -1106,10 +1172,12 @@ def build_context_artifact(
 ) -> Dict:
     """Build the canonical JSON context artifact."""
     warnings_out = list(warnings or [])
-    intent_type = detect_intent(task)
+    intent_scores = _intent_scores(task)
+    intent_type = _pick_by_precedence(intent_scores, INTENT_PRECEDENCE, "implement_feature")
     components = detect_components(task, wiki_root, packs)
     domain, scope = detect_scope(task, wiki_root, workspace)
-    workstream = detect_workstream(task, packs, components)
+    workstream_scores = _workstream_scores(task, packs, components)
+    workstream = _pick_by_precedence(workstream_scores, WORKSTREAM_PRECEDENCE, "engineering")
     meta = WORKSTREAM_PRIORITY.get(workstream, WORKSTREAM_PRIORITY["engineering"])
     candidates, gaps = _collect_candidates(
         intent_type,
@@ -1152,6 +1220,10 @@ def build_context_artifact(
                 Path(doc["path"]).stem for doc in docs if doc["category"] == "pattern"
             ],
             "contracts_touched": _contracts_touched(docs),
+            "classification": {
+                "intent": _classification_summary(intent_scores, intent_type),
+                "workstream": _classification_summary(workstream_scores, workstream),
+            },
         },
         "referenced_docs": docs,
         "static_context": static_docs,

--- a/scripts/lint-wiki.py
+++ b/scripts/lint-wiki.py
@@ -44,6 +44,7 @@ from typing import Any
 from urllib.parse import unquote, urlparse
 
 from lib import contextd_resolver
+from lib.stdio import configure_stdio
 
 # Markdown inline link: [text](target)
 # - Skips images (preceding '!') by using a negative lookbehind.
@@ -232,6 +233,7 @@ def print_human_summary(res: dict, stream) -> None:
 
 
 def main(argv: list[str] | None = None) -> int:
+    configure_stdio()
     ap = argparse.ArgumentParser(description="Lint wiki workspaces for broken links and orphans.")
     ap.add_argument("--workspace", help="Workspace name (under {wiki-root}/workspaces/)")
     ap.add_argument("--wiki-root", help="Override wiki root directory")

--- a/scripts/mcp_server.py
+++ b/scripts/mcp_server.py
@@ -27,6 +27,7 @@ import contextd_resolver  # noqa: E402
 import context_security  # noqa: E402
 import find_engine  # noqa: E402
 import task_context_engine  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 
 LATEST_PROTOCOL_VERSION = "2025-11-25"
@@ -818,6 +819,7 @@ def build_parser() -> argparse.ArgumentParser:
 
 
 def main(argv: Optional[List[str]] = None) -> int:
+    configure_stdio()
     parser = build_parser()
     args = parser.parse_args(argv)
     options = ServerOptions(

--- a/scripts/render_runtime.py
+++ b/scripts/render_runtime.py
@@ -21,6 +21,7 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 import cmd_resolve  # noqa: E402
 import cmd_bundle  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 REPO_ROOT = SCRIPT_DIR.parent
 
@@ -469,6 +470,7 @@ def render(runtime: str, workspace: Optional[str] = None,
 
 
 def main():
+    configure_stdio()
     import argparse
     parser = argparse.ArgumentParser(description="Export contextd knowledge to runtime-specific formats.")
     parser.add_argument("--runtime", required=True,

--- a/scripts/render_trace.py
+++ b/scripts/render_trace.py
@@ -33,6 +33,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 import contextd_resolver  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 STAGE_FILES = [
     "run.json",
@@ -895,6 +896,7 @@ def watch_loop(run_dir: Path, workspace_active: str | None, out_path: Path) -> i
 
 
 def main() -> int:
+    configure_stdio()
     p = argparse.ArgumentParser(description="Render contextd pipeline trace as HTML.")
     p.add_argument("--run", help="Run ID (or prefix)")
     p.add_argument("--last", action="store_true", help="Latest run")

--- a/scripts/scaffold-pack.py
+++ b/scripts/scaffold-pack.py
@@ -37,6 +37,8 @@ import sys
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+
+from lib.stdio import configure_stdio  # noqa: E402
 PACKS_DIR = REPO_ROOT / "packs"
 TEMPLATE_PACK_YAML = REPO_ROOT / "templates" / "pack.yaml"
 
@@ -49,6 +51,7 @@ def die(msg: str) -> None:
 
 
 def main() -> None:
+    configure_stdio()
     if len(sys.argv) != 2:
         die("Usage: python scripts/scaffold-pack.py <pack-name>")
 

--- a/scripts/test_contextd_runtime.py
+++ b/scripts/test_contextd_runtime.py
@@ -756,12 +756,75 @@ def test_pack_ui_ux_rules() -> None:
     print("  ok pack_ui_ux_rules")
 
 
+def test_stdio_utf8_under_legacy_codepage() -> None:
+    """CLI must not crash writing/reading non-ASCII under a legacy codepage.
+
+    Forces PYTHONIOENCODING=cp1252 (the historical Windows console default)
+    to prove lib/stdio.py's configure_stdio() reconfiguration — not an
+    environment variable the caller happens to set — is what makes this work.
+    """
+    env = os.environ.copy()
+    env["PYTHONIOENCODING"] = "cp1252"
+    env.pop("PYTHONUTF8", None)
+    task = "đánh giá context drift với kiểm tra"
+    for args in (
+        ["context", task, "--preview", "--format", "markdown"],
+        ["context", task, "--preview", "--format", "json"],
+        ["explain", task, "--format", "text"],
+        ["check"],
+    ):
+        proc = subprocess.run(
+            [sys.executable, "-m", "scripts.cli", *args],
+            cwd=str(ROOT), text=True, encoding="utf-8", capture_output=True, env=env,
+        )
+        assert proc.returncode == 0, (args, proc.stdout, proc.stderr)
+    print("  ok stdio_utf8_under_legacy_codepage")
+
+
+def test_intent_classification_word_boundaries() -> None:
+    """Keyword matching must respect word boundaries, not bare substrings."""
+    from lib import task_context_engine as tce
+
+    cases = [
+        ("build a new payment service", "implement_feature", "engineering"),
+        ("check why the consumer fails", "fix_bug", "engineering"),
+        ("add rapid api endpoint", "implement_feature", "engineering"),
+        ("fix the checkout crash", "fix_bug", "engineering"),
+        ("debug context quality", "fix_bug", None),
+    ]
+    for task, expected_intent, expected_workstream in cases:
+        intent = tce.detect_intent(task)
+        assert intent == expected_intent, (task, intent, expected_intent)
+        if expected_workstream is not None:
+            workstream = tce.detect_workstream(task, [], [])
+            assert workstream == expected_workstream, (task, workstream, expected_workstream)
+    print("  ok intent_classification_word_boundaries")
+
+
+def test_pack_keyword_special_chars() -> None:
+    """Punctuation-heavy keywords (.proto, @RestController) must still match."""
+    from lib import task_context_engine as tce
+
+    assert "grpc" in tce.detect_components(
+        "update service.proto stub", ROOT, ["pack-web-api"])
+    assert "rest" in tce.detect_components(
+        "add @RestController route", ROOT, ["pack-web-api"])
+    assert "drift-check" in tce.detect_components(
+        "drift-check accepted decisions", ROOT, ["pack-operator-steering"])
+    print("  ok pack_keyword_special_chars")
+
+
 def test_cli_ux_help_and_aliases() -> None:
     def run_cli(args: list[str]) -> subprocess.CompletedProcess:
+        # contextd forces UTF-8 on its own stdout (see lib/stdio.py) regardless
+        # of the OS console codepage, so decode captured output as UTF-8 too —
+        # otherwise a locale-default decode (e.g. cp1252 on Windows) breaks on
+        # the workspace's non-ASCII content.
         return subprocess.run(
             [sys.executable, "-m", "scripts.cli", *args],
             cwd=str(ROOT),
             text=True,
+            encoding="utf-8",
             capture_output=True,
         )
 
@@ -842,7 +905,10 @@ def test_cli_smoke() -> None:
                 "--runtime", runtime, "--output", str(out_dir),
             ])
         for cmd in commands:
-            proc = subprocess.run(cmd, cwd=str(ROOT), text=True, capture_output=True)
+            # See run_cli() note above: decode as UTF-8 to match contextd's
+            # forced-UTF-8 stdout, independent of the OS console codepage.
+            proc = subprocess.run(cmd, cwd=str(ROOT), text=True, encoding="utf-8",
+                                  capture_output=True)
             assert proc.returncode == 0, (cmd, proc.stdout, proc.stderr)
         for runtime, expected in expected_exports.items():
             for rel in expected:
@@ -874,6 +940,7 @@ def test_mcp_server_smoke() -> None:
             ],
             cwd=str(ROOT),
             text=True,
+            encoding="utf-8",
             stdin=subprocess.PIPE,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -1275,6 +1342,9 @@ def run() -> int:
         test_doctor_and_adapter_drift_checks,
         test_codex_agents_use_json_canonical_artifact,
         test_pack_ui_ux_rules,
+        test_stdio_utf8_under_legacy_codepage,
+        test_intent_classification_word_boundaries,
+        test_pack_keyword_special_chars,
         test_cli_ux_help_and_aliases,
         test_cli_smoke,
         test_mcp_server_smoke,

--- a/scripts/validate.py
+++ b/scripts/validate.py
@@ -59,6 +59,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent))
 sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
 import pack_loader  # noqa: E402
 import contextd_resolver  # noqa: E402
+from stdio import configure_stdio  # noqa: E402
 
 
 # ---------------------------------------------------------------------------
@@ -337,6 +338,7 @@ def run(file_path: Path, ws_root: Optional[Path], domain: Optional[str],
 
 
 def main(argv: List[str]) -> int:
+    configure_stdio()
     parser = argparse.ArgumentParser(
         prog="validate.py",
         description="Layer 1 rule-based validator — see "


### PR DESCRIPTION
Two bugs found during a full source review, both reproducible on a default Windows console (cp1252):

- Every CLI/MCP entry point wrote/read stdio using the OS console codepage. Any workspace doc containing non-ASCII content (this repo has Vietnamese text throughout) crashed `contextd context`, `explain`, `check`, and `mcp-server` with UnicodeEncodeError/ UnicodeDecodeError. Added scripts/lib/stdio.py:configure_stdio() and call it first thing in main() of all 24 script entry points.

- detect_intent/detect_workstream/detect_components/_score in task_context_engine.py matched keywords via bare `in` substring checks, so short keywords matched inside unrelated words ("api" in "rapid", "ui" in "build", "check" in "checkout"), silently steering task classification (and therefore document selection) to the wrong workstream. Replaced with word-boundary regex matching that still allows punctuation-only keywords (".proto", "@RestController") and hyphen/underscore/slash joins ("drift check" ~ "drift-check"), and made intent/workstream tie-breaks deterministic via an explicit precedence order instead of relying on dict iteration order. Exposed the scoring as intent.classification in the context artifact for `explain`.

  This surfaced an existing golden-task pass that only worked by accident ("bug" matching inside "debug"); added "debug" to the fix_bug keyword list to restore intended behavior on purpose.

Also fixed two of contextd's own tests that broke as a direct consequence of the stdio fix: subprocess.run(text=True) without an explicit encoding now decodes the child's guaranteed-UTF-8 output using the parent's locale-default codepage instead.

Verified: all 4 test suites green (test_lint_wiki, test_atomic_write, test_detect_repetition, test_contextd_runtime — including 3 new regression tests), plus doctor/pack-validate/eval --golden/lint-wiki all clean. Confirmed via `git stash` that the 3 remaining test_contextd_runtime failures (WSL/Git Bash unavailable on this machine) are pre-existing and unrelated.

## Summary / Context

<!-- What changed? Keep scope focused. -->

## Problem & Why

<!-- What problem does this solve, and why is this change needed? -->

## Test Notes

- [ ] `python scripts/test_lint_wiki.py`
- [ ] `python scripts/test_atomic_write.py`
- [ ] `python scripts/test_detect_repetition.py`
- [ ] `python scripts/lint-wiki.py --all-workspaces --wiki-root .`
- [ ] N/A (reason):

## Related Issues

<!-- Closes #... / Relates to #... -->

## Docs / Workflow Impact

- [ ] Updated docs because behavior/workflow changed
- [ ] No docs update needed (reason):

## Wiki-specific checks

- [ ] Preserved workspace isolation
- [ ] No cross-workspace knowledge mixing
- [ ] Avoided duplicate docs/patterns

## Project Spirit Check

- [ ] Change reinforces knowledge-first workflow (contracts/patterns before invention)
- [ ] Contributor experience stays simple and practical (no unnecessary complexity)
- [ ] Project voice and intent remain consistent across docs/workflows
- [ ] If trade-offs were made, rationale is stated clearly in this PR
