### PR TITLE
feat: add DevOps IaC pack

### DIFF
--- a/.contextd/manifest.json
+++ b/.contextd/manifest.json
@@ -273,6 +273,20 @@
       "template_file": "packs/pack-dba/pack.yaml"
     },
     {
+      "name": "pack-devops-iac",
+      "description": "DevOps and infrastructure-as-code pack — Terraform dependency safety, Kubernetes workload readiness, CI/CD deployment gates, environment promotion, drift control, and rollback readiness.",
+      "version": "0.1.0",
+      "components": [
+        "terraform-safety",
+        "kubernetes-workload",
+        "ci-cd-release",
+        "environment-promotion",
+        "infrastructure-drift",
+        "rollback-readiness"
+      ],
+      "template_file": "packs/pack-devops-iac/pack.yaml"
+    },
+    {
       "name": "pack-event-driven",
       "description": "Kafka, MQTT, and event-driven backend patterns (DLQ, offset commit, idempotent consumer, batch processing)",
       "version": "1.0.0",

--- a/packs/README.md
+++ b/packs/README.md
@@ -87,10 +87,11 @@ This generates all 8 files (pack.yaml, README, 5 agent docs, scripts/rules.py wi
 | [pack-ba](pack-ba/) | beta (v0.1) | Business analysis knowledge — requirements modeling, acceptance criteria, process mapping, stakeholder alignment. For **BA** users needing requirement clarity/testability |
 | [pack-security](pack-security/) | beta (v0.2) | Security engineering + authorized pentest — threat modeling, authz boundaries, secret hygiene, logging redaction, scope discipline, evidence-based findings, risk rating, remediation reporting. Absorbs former `pack-pentest` |
 | [pack-dba](pack-dba/) | beta (v0.1) | Database administration knowledge — migration rollback safety, query evidence, backup/restore readiness, DB operational guardrails |
+| [pack-devops-iac](pack-devops-iac/) | beta (v0.1) | DevOps + infrastructure as code — Terraform dependency safety, Kubernetes workload readiness, CI/CD plan gates, promotion, drift, and rollback controls |
 | [pack-solo-builder](pack-solo-builder/) | beta (v0.1) | For **non-technical domain experts** (mechanical, accounting, healthcare, ...) using Claude Code as a "no-code IDE" — tool design coach + cross-platform tech recipe library (Linux native + Windows Docker). Pairs with `/tool-design`, `/tool-list`, `/tool-extend` |
 | [pack-ui-ux](pack-ui-ux/) | beta (v0.1) | UI/UX design — design system, design tokens, WCAG 2.1 AA accessibility, user flows, UX writing conventions. Pairs with `pack-frontend-react` (design doc ↔ code impl) |
 
-Roadmap (Phase 3+): `pack-mobile-react-native`, `pack-mobile-flutter`, `pack-mobile-ios-swift`, `pack-mobile-android-kotlin`, `pack-data-engineering`, `pack-ml-training`, `pack-devops-iac`.
+Roadmap (Phase 3+): `pack-mobile-react-native`, `pack-mobile-flutter`, `pack-mobile-ios-swift`, `pack-mobile-android-kotlin`, `pack-data-engineering`, `pack-ml-training`.
 
 ## Composition examples
 

--- a/packs/pack-devops-iac/README.md
+++ b/packs/pack-devops-iac/README.md
@@ -1,0 +1,51 @@
+# pack-devops-iac
+
+DevOps and infrastructure-as-code guardrails for Terraform/OpenTofu, Kubernetes workloads, CI/CD releases, environment promotion, drift control, and rollback readiness.
+
+## When to enable
+
+Add `- pack-devops-iac` under `## Packs` in `workspaces/{ws}/workspace.md` when a workspace:
+
+- Manages infrastructure with Terraform or OpenTofu.
+- Deploys Kubernetes workloads or Helm-rendered manifests.
+- Owns CI/CD workflows that change shared or production environments.
+- Needs explicit promotion, drift, blast-radius, or rollback controls.
+
+## What it adds
+
+- **Constraints** (`agents/constraints.md`) — hard infrastructure and deployment safety rules.
+- **Working rules** (`agents/coding-rules.md`) — reviewable IaC and release conventions.
+- **Common pitfalls** (`agents/common-pitfalls.md`) — ten recurring operational failure modes.
+- **Validator rules** (`agents/pipeline/validator-rules.md`, `scripts/rules.py`) — narrow static checks for common unsafe changes.
+- **Retrieval map** (`agents/pipeline/retrieval-map.md`) — component-to-workspace knowledge mapping.
+- **Prompt overrides** (`agents/pipeline/prompt-overrides.md`) — DevOps/IaC self-checks.
+
+## Components declared
+
+- `terraform-safety`
+- `kubernetes-workload`
+- `ci-cd-release`
+- `environment-promotion`
+- `infrastructure-drift`
+- `rollback-readiness`
+
+## Composition
+
+- Pair with `pack-security` for IAM, secret handling, image vulnerability, and supply-chain controls.
+- Pair with `pack-qc` for performance baselines and release-quality evidence.
+- Pair with `pack-dba` when a deployment includes schema changes, backup, or restore obligations.
+
+This pack does not duplicate those concerns. It owns infrastructure change mechanics and operational deployment safety.
+
+## Heuristic scope
+
+Layer-1 validators intentionally cover only reliable textual signals. They do not attempt to fully parse HCL, YAML templating, reusable workflows, or rendered Helm output. Complex changes require the Layer-2 self-checks.
+
+## Conflicts with
+
+(none)
+
+## Related
+
+- Pack mechanism: [`packs/README.md`](../README.md)
+- Cross-cutting principles: [`agents/cross-cutting-principles.md`](../../agents/cross-cutting-principles.md)

--- a/packs/pack-devops-iac/agents/coding-rules.md
+++ b/packs/pack-devops-iac/agents/coding-rules.md
@@ -1,0 +1,23 @@
+# pack-devops-iac — Working Rules
+
+## Infrastructure changes
+
+- Keep reusable modules small, versioned, and explicit about inputs, outputs, and ownership.
+- Separate environment-specific values from reusable infrastructure definitions.
+- Attach the plan/diff and summarize creates, updates, replacements, and destroys in review.
+- Prefer staged changes when provider, state, networking, or identity boundaries change.
+- Treat generated plans as review evidence, not as durable secrets-safe artifacts by default.
+
+## Kubernetes workloads
+
+- Use immutable image digests for production where the delivery platform supports them.
+- Base requests and autoscaling thresholds on observed demand; label provisional values for follow-up.
+- Design probes around service readiness rather than process existence.
+- Validate rendered manifests when Helm, Kustomize, or another generator is used.
+
+## Delivery and operations
+
+- Build once, attest once, and promote the same artifact through environments.
+- Make concurrency and cancellation behavior explicit for environment-changing workflows.
+- Record drift findings separately from approved changes; reconcile them through the normal review path.
+- Test rollback commands and verification signals before relying on a runbook during an incident.

--- a/packs/pack-devops-iac/agents/coding-rules.md
+++ b/packs/pack-devops-iac/agents/coding-rules.md
@@ -10,7 +10,7 @@
 
 ## Kubernetes workloads
 
-- Use immutable image digests for production where the delivery platform supports them.
+- Use digest-pinned images for long-running workloads; resolve release tags to digests before deployment.
 - Base requests and autoscaling thresholds on observed demand; label provisional values for follow-up.
 - Design probes around service readiness rather than process existence.
 - Validate rendered manifests when Helm, Kustomize, or another generator is used.

--- a/packs/pack-devops-iac/agents/common-pitfalls.md
+++ b/packs/pack-devops-iac/agents/common-pitfalls.md
@@ -10,17 +10,17 @@ Anti-patterns for infrastructure changes and deployment operations. Additive on 
 - **Severity**: error
 
 ## P02 — Floating remote module
-- **NG**: use an unversioned registry module or Git branch.
-- **OK**: set a registry `version` or immutable Git `ref`.
+- **NG**: use an unversioned registry module, Git branch, tag, or short SHA.
+- **OK**: set a registry `version` or a full 40-hex Git commit `ref`.
 - **Why**: identical source code can produce different infrastructure plans over time.
 - **Detect**: Layer-1 `pack-devops-iac-terraform-unpinned-module`.
 - **Severity**: error
 
-## P03 — Mutable workload image
-- **NG**: deploy `image: service:latest`.
-- **OK**: deploy a release tag or digest that identifies one artifact.
+## P03 — Image not digest-pinned
+- **NG**: deploy an untagged image or any tag, including `stable` or `v1.2.3`.
+- **OK**: deploy `image: repository@sha256:<64-hex-digest>`.
 - **Why**: rollback and audit evidence become nondeterministic.
-- **Detect**: Layer-1 `pack-devops-iac-k8s-mutable-image-tag`.
+- **Detect**: Layer-1 `pack-devops-iac-k8s-image-not-digest-pinned`.
 - **Severity**: error
 
 ## P04 — Traffic before readiness
@@ -38,10 +38,10 @@ Anti-patterns for infrastructure changes and deployment operations. Additive on 
 - **Severity**: warn
 
 ## P06 — Apply without a plan gate
-- **NG**: CI runs `terraform apply` without producing or consuming a plan.
-- **OK**: review a plan and apply the reviewed plan artifact.
+- **NG**: CI runs `terraform plan`, then `terraform apply -auto-approve` without passing the saved plan to apply.
+- **OK**: review a saved plan and pass that plan artifact as the positional argument to every apply command.
 - **Why**: reviewers cannot see the actual infrastructure mutation.
-- **Detect**: Layer-1 `pack-devops-iac-terraform-apply-without-plan`.
+- **Detect**: Layer-1 `pack-devops-iac-terraform-apply-without-saved-plan`.
 - **Severity**: error
 
 ## P07 — Rebuild during promotion
@@ -78,10 +78,10 @@ Anti-patterns for infrastructure changes and deployment operations. Additive on 
 |---|---|---|
 | P01 provider pinning | `pack-devops-iac-terraform-unpinned-provider` | ✓ |
 | P02 module pinning | `pack-devops-iac-terraform-unpinned-module` | ✓ |
-| P03 image immutability | `pack-devops-iac-k8s-mutable-image-tag` | ✓ |
+| P03 image immutability | `pack-devops-iac-k8s-image-not-digest-pinned` | ✓ |
 | P04 readiness | `pack-devops-iac-k8s-missing-readiness-probe` | ✓ |
 | P05 resource requests | `pack-devops-iac-k8s-missing-resource-requests` | ✓ |
-| P06 plan gate | `pack-devops-iac-terraform-apply-without-plan` | ✓ |
+| P06 plan gate | `pack-devops-iac-terraform-apply-without-saved-plan` | ✓ |
 | P07 promotion | — | ✓ |
 | P08 drift | — | ✓ |
 | P09 rollback | `pack-devops-iac-deployment-no-rollback` | ✓ |

--- a/packs/pack-devops-iac/agents/common-pitfalls.md
+++ b/packs/pack-devops-iac/agents/common-pitfalls.md
@@ -1,0 +1,88 @@
+# pack-devops-iac — Top 10 Common Pitfalls
+
+Anti-patterns for infrastructure changes and deployment operations. Additive on [constraints.md](constraints.md).
+
+## P01 — Floating Terraform provider
+- **NG**: declare a provider source without a version constraint.
+- **OK**: constrain the provider and upgrade it in a reviewed dependency change.
+- **Why**: an unrelated initialization can select an incompatible provider.
+- **Detect**: Layer-1 `pack-devops-iac-terraform-unpinned-provider`.
+- **Severity**: error
+
+## P02 — Floating remote module
+- **NG**: use an unversioned registry module or Git branch.
+- **OK**: set a registry `version` or immutable Git `ref`.
+- **Why**: identical source code can produce different infrastructure plans over time.
+- **Detect**: Layer-1 `pack-devops-iac-terraform-unpinned-module`.
+- **Severity**: error
+
+## P03 — Mutable workload image
+- **NG**: deploy `image: service:latest`.
+- **OK**: deploy a release tag or digest that identifies one artifact.
+- **Why**: rollback and audit evidence become nondeterministic.
+- **Detect**: Layer-1 `pack-devops-iac-k8s-mutable-image-tag`.
+- **Severity**: error
+
+## P04 — Traffic before readiness
+- **NG**: a long-running workload has containers but no readiness probe.
+- **OK**: define a readiness signal aligned with the service dependency contract.
+- **Why**: schedulers can route traffic before the workload can serve it safely.
+- **Detect**: Layer-1 `pack-devops-iac-k8s-missing-readiness-probe`.
+- **Severity**: warn
+
+## P05 — Unschedulable resource intent
+- **NG**: omit resource requests from a long-running workload.
+- **OK**: declare evidence-based or explicitly provisional CPU and memory requests.
+- **Why**: placement and capacity behavior becomes accidental.
+- **Detect**: Layer-1 `pack-devops-iac-k8s-missing-resource-requests`.
+- **Severity**: warn
+
+## P06 — Apply without a plan gate
+- **NG**: CI runs `terraform apply` without producing or consuming a plan.
+- **OK**: review a plan and apply the reviewed plan artifact.
+- **Why**: reviewers cannot see the actual infrastructure mutation.
+- **Detect**: Layer-1 `pack-devops-iac-terraform-apply-without-plan`.
+- **Severity**: error
+
+## P07 — Rebuild during promotion
+- **NG**: production rebuilds an artifact from the same commit.
+- **OK**: promote the exact artifact verified in the previous environment.
+- **Why**: the production artifact may differ from the tested artifact.
+- **Detect**: Layer-2 self-check.
+- **Severity**: error
+
+## P08 — Drift with no owner
+- **NG**: periodic plan output exists but nobody owns triage or reconciliation.
+- **OK**: define cadence, owner, notification route, and reconciliation workflow.
+- **Why**: unmanaged drift silently invalidates the declared desired state.
+- **Detect**: Layer-2 self-check.
+- **Severity**: warn
+
+## P09 — Rollback as a slogan
+- **NG**: a release runbook says “rollback if needed” without criteria or verification.
+- **OK**: name trigger, owner, commands, data implications, and success signals.
+- **Why**: an incident is the worst time to invent recovery mechanics.
+- **Detect**: Layer-1 `pack-devops-iac-deployment-no-rollback` plus Layer-2 self-check.
+- **Severity**: warn
+
+## P10 — Hidden blast radius
+- **NG**: approve a plan without calling out replacements, destroys, or environment reach.
+- **OK**: summarize affected resources, environments, dependencies, and irreversible operations.
+- **Why**: a syntactically small change can have a large operational impact.
+- **Detect**: Layer-2 self-check.
+- **Severity**: error
+
+## Mapping to validator
+
+| Pitfall | Layer-1 rule ID | Layer-2 self-check |
+|---|---|---|
+| P01 provider pinning | `pack-devops-iac-terraform-unpinned-provider` | ✓ |
+| P02 module pinning | `pack-devops-iac-terraform-unpinned-module` | ✓ |
+| P03 image immutability | `pack-devops-iac-k8s-mutable-image-tag` | ✓ |
+| P04 readiness | `pack-devops-iac-k8s-missing-readiness-probe` | ✓ |
+| P05 resource requests | `pack-devops-iac-k8s-missing-resource-requests` | ✓ |
+| P06 plan gate | `pack-devops-iac-terraform-apply-without-plan` | ✓ |
+| P07 promotion | — | ✓ |
+| P08 drift | — | ✓ |
+| P09 rollback | `pack-devops-iac-deployment-no-rollback` | ✓ |
+| P10 blast radius | — | ✓ |

--- a/packs/pack-devops-iac/agents/constraints.md
+++ b/packs/pack-devops-iac/agents/constraints.md
@@ -5,12 +5,12 @@ Hard DevOps and infrastructure-as-code rules. Additive on the engine constraints
 ## Terraform and OpenTofu
 
 - `pack-devops-iac-terraform-provider-pinned` — Every non-local provider dependency MUST declare a version constraint. Provider upgrades are reviewed changes, not ambient resolver behavior.
-- `pack-devops-iac-terraform-module-pinned` — Every remote module MUST use an immutable version or Git ref. Floating branches and unversioned registry modules are forbidden.
-- `pack-devops-iac-plan-before-apply` — Automated apply workflows MUST produce or consume a reviewed plan before changing infrastructure.
+- `pack-devops-iac-terraform-module-pinned` — Every remote module MUST use a registry version or full Git commit SHA. Branches, tags, short SHAs, and unversioned registry modules are forbidden.
+- `pack-devops-iac-plan-before-apply` — Every automated apply command MUST consume an explicit reviewed saved-plan argument before changing infrastructure.
 
 ## Kubernetes workloads
 
-- `pack-devops-iac-k8s-immutable-image` — Workload images MUST use an immutable tag or digest. `latest` is forbidden.
+- `pack-devops-iac-k8s-immutable-image` — Every long-running workload container image MUST be pinned by `sha256` digest. Untagged images and all tags are mutable references and are forbidden.
 - `pack-devops-iac-k8s-readiness-probe` — Long-running workload containers MUST define a readiness probe or document why an external readiness mechanism applies.
 - `pack-devops-iac-k8s-resource-requests` — Long-running workload containers MUST declare resource requests based on measured or explicitly provisional values.
 

--- a/packs/pack-devops-iac/agents/constraints.md
+++ b/packs/pack-devops-iac/agents/constraints.md
@@ -1,0 +1,28 @@
+# pack-devops-iac — Constraints
+
+Hard DevOps and infrastructure-as-code rules. Additive on the engine constraints; strict-only.
+
+## Terraform and OpenTofu
+
+- `pack-devops-iac-terraform-provider-pinned` — Every non-local provider dependency MUST declare a version constraint. Provider upgrades are reviewed changes, not ambient resolver behavior.
+- `pack-devops-iac-terraform-module-pinned` — Every remote module MUST use an immutable version or Git ref. Floating branches and unversioned registry modules are forbidden.
+- `pack-devops-iac-plan-before-apply` — Automated apply workflows MUST produce or consume a reviewed plan before changing infrastructure.
+
+## Kubernetes workloads
+
+- `pack-devops-iac-k8s-immutable-image` — Workload images MUST use an immutable tag or digest. `latest` is forbidden.
+- `pack-devops-iac-k8s-readiness-probe` — Long-running workload containers MUST define a readiness probe or document why an external readiness mechanism applies.
+- `pack-devops-iac-k8s-resource-requests` — Long-running workload containers MUST declare resource requests based on measured or explicitly provisional values.
+
+## Releases and operations
+
+- `pack-devops-iac-production-promotion` — Production changes MUST be promoted from a previously verified artifact; production MUST NOT rebuild a different artifact from the same source.
+- `pack-devops-iac-rollback-required` — Deployment design and runbooks MUST define rollback or roll-forward criteria, commands, ownership, and verification.
+- `pack-devops-iac-drift-owned` — Managed infrastructure MUST have a documented drift detection cadence, owner, and reconciliation path.
+- `pack-devops-iac-blast-radius-reviewed` — Infrastructure changes MUST identify affected environments/resources and destructive or replacement operations before approval.
+
+## Related
+
+- Engine baseline: [`agents/constraints.md`](../../../agents/constraints.md)
+- Validator catalog: [pipeline/validator-rules.md](pipeline/validator-rules.md)
+- Working rules: [coding-rules.md](coding-rules.md)

--- a/packs/pack-devops-iac/agents/pipeline/prompt-overrides.md
+++ b/packs/pack-devops-iac/agents/pipeline/prompt-overrides.md
@@ -1,0 +1,26 @@
+# pack-devops-iac — Prompt Overrides
+
+Pack-specific additions injected when this pack is active.
+
+## System prompt addition
+
+For infrastructure and deployment work, treat the reviewed change plan, immutable artifact identity, environment scope, drift ownership, and recovery procedure as part of correctness. Separate mechanically detectable defects from design checks. Do not infer provider behavior, production topology, promotion policy, or rollback safety when workspace knowledge is missing.
+
+## Builder prompt self-check (additions)
+
+```md
+### DevOps and IaC (pack-devops-iac)
+- Remote Terraform/OpenTofu providers and modules are versioned immutably.
+- The reviewed plan identifies creates, updates, replacements, destroys, and affected environments.
+- Automated apply consumes or follows a reviewed plan.
+- Kubernetes workload images are immutable; readiness and resource requests are explicit.
+- Production promotes the same artifact verified in the preceding environment.
+- Drift detection has a cadence, owner, notification route, and reconciliation workflow.
+- Rollback or roll-forward defines trigger, owner, commands, data implications, and verification.
+- Generated/rendered infrastructure is validated, not only its template source.
+- Security, performance, and database-specific concerns are delegated to their active packs without duplicating or weakening them.
+```
+
+## Common Pitfalls
+
+Before completion, check P01–P10 in [`../common-pitfalls.md`](../common-pitfalls.md). Confirm all Layer-1 `pack-devops-iac-*` validators pass and explicitly evaluate each Layer-2-only item.

--- a/packs/pack-devops-iac/agents/pipeline/prompt-overrides.md
+++ b/packs/pack-devops-iac/agents/pipeline/prompt-overrides.md
@@ -12,8 +12,8 @@ For infrastructure and deployment work, treat the reviewed change plan, immutabl
 ### DevOps and IaC (pack-devops-iac)
 - Remote Terraform/OpenTofu providers and modules are versioned immutably.
 - The reviewed plan identifies creates, updates, replacements, destroys, and affected environments.
-- Automated apply consumes or follows a reviewed plan.
-- Kubernetes workload images are immutable; readiness and resource requests are explicit.
+- Every automated apply command consumes an explicit reviewed saved-plan argument.
+- Every Kubernetes workload container is checked independently for a digest-pinned image, readiness probe, and resource requests.
 - Production promotes the same artifact verified in the preceding environment.
 - Drift detection has a cadence, owner, notification route, and reconciliation workflow.
 - Rollback or roll-forward defines trigger, owner, commands, data implications, and verification.

--- a/packs/pack-devops-iac/agents/pipeline/retrieval-map.md
+++ b/packs/pack-devops-iac/agents/pipeline/retrieval-map.md
@@ -1,0 +1,14 @@
+# pack-devops-iac — Retrieval Map
+
+Component → workspace knowledge mapping for this pack. Merged into the engine retrieval map.
+
+| Component | Docs to retrieve |
+|-----------|------------------|
+| `terraform-safety` | `platform/patterns/terraform-change-management.md`, `platform/contracts/infrastructure-state-contract.md`, `decisions/`, `runbooks/` |
+| `kubernetes-workload` | `platform/patterns/kubernetes-workload.md`, `platform/contracts/deployment-contract.md`, `projects/{project}/knowledge-map.md`, `runbooks/` |
+| `ci-cd-release` | `platform/patterns/ci-cd-release.md`, `platform/contracts/deployment-contract.md`, `projects/{project}/knowledge-map.md`, `runbooks/` |
+| `environment-promotion` | `platform/patterns/environment-promotion.md`, `platform/contracts/deployment-contract.md`, `decisions/`, `runbooks/` |
+| `infrastructure-drift` | `platform/patterns/infrastructure-drift.md`, `projects/{project}/knowledge-map.md`, `runbooks/`, `evidence/` |
+| `rollback-readiness` | `platform/contracts/deployment-contract.md`, `runbooks/`, `projects/{project}/knowledge-map.md`, `evidence/` |
+
+Components must match `pack.yaml#components`. Missing workspace documents are explicit knowledge gaps; the pack does not borrow another workspace's infrastructure decisions.

--- a/packs/pack-devops-iac/agents/pipeline/validator-rules.md
+++ b/packs/pack-devops-iac/agents/pipeline/validator-rules.md
@@ -7,11 +7,11 @@ Layer-1 static checks implemented in [`scripts/rules.py`](../../scripts/rules.py
 | Rule ID | Severity | Triggers on | Detects |
 |---------|----------|-------------|---------|
 | `pack-devops-iac-terraform-unpinned-provider` | error | `*.tf` | A `required_providers` entry with `source` but no version constraint in the same provider block. |
-| `pack-devops-iac-terraform-unpinned-module` | error | `*.tf` | A remote module block without a registry version or immutable Git `ref`. |
-| `pack-devops-iac-k8s-mutable-image-tag` | error | `*.yaml`, `*.yml` | A Kubernetes workload image using the `latest` tag. |
-| `pack-devops-iac-k8s-missing-readiness-probe` | warn | `*.yaml`, `*.yml` | A Deployment, StatefulSet, or DaemonSet with containers but no readiness probe. |
-| `pack-devops-iac-k8s-missing-resource-requests` | warn | `*.yaml`, `*.yml` | A Deployment, StatefulSet, or DaemonSet with containers but no resource requests. |
-| `pack-devops-iac-terraform-apply-without-plan` | error | CI workflow YAML | A workflow invokes `terraform`/`tofu apply` without a plan command or saved-plan input. |
+| `pack-devops-iac-terraform-unpinned-module` | error | `*.tf` | A remote module block without a registry version or full 40-hex Git commit `ref`. |
+| `pack-devops-iac-k8s-image-not-digest-pinned` | error | `*.yaml`, `*.yml` | A workload container image that is not pinned by a 64-hex `sha256` digest. |
+| `pack-devops-iac-k8s-missing-readiness-probe` | warn | `*.yaml`, `*.yml` | An individual container in a Deployment, StatefulSet, or DaemonSet document without a readiness probe. |
+| `pack-devops-iac-k8s-missing-resource-requests` | warn | `*.yaml`, `*.yml` | An individual container in a Deployment, StatefulSet, or DaemonSet document without resource requests. |
+| `pack-devops-iac-terraform-apply-without-saved-plan` | error | CI workflow YAML | An individual `terraform`/`tofu apply` command without an explicit positional saved-plan argument. |
 | `pack-devops-iac-deployment-no-rollback` | warn | deployment/release/runbook Markdown | Deployment instructions with no rollback, roll-back, roll-forward, or rollout-undo path. |
 
 ## Layer-2 checks
@@ -26,6 +26,6 @@ Layer-1 static checks implemented in [`scripts/rules.py`](../../scripts/rules.py
 ## Heuristic limitations
 
 - HCL checks use brace-local text inspection and do not evaluate expressions.
-- Kubernetes checks inspect complete YAML files, not individual multi-document workload boundaries.
-- CI checks recognize common workflow paths and explicit `plan` commands or plan-file inputs.
+- Kubernetes checks split standard `---` documents and use indentation to scope `containers`; generated templates still require rendered-manifest validation.
+- CI checks inspect each apply independently. They verify an explicit positional plan argument, but cannot prove that an external artifact was reviewed.
 - Markdown rollback checks only target filenames or directories associated with deployments, releases, or runbooks.

--- a/packs/pack-devops-iac/agents/pipeline/validator-rules.md
+++ b/packs/pack-devops-iac/agents/pipeline/validator-rules.md
@@ -1,0 +1,31 @@
+# pack-devops-iac — Validator Rules
+
+Layer-1 static checks implemented in [`scripts/rules.py`](../../scripts/rules.py). Rule IDs use the `pack-devops-iac-` prefix.
+
+## Catalog
+
+| Rule ID | Severity | Triggers on | Detects |
+|---------|----------|-------------|---------|
+| `pack-devops-iac-terraform-unpinned-provider` | error | `*.tf` | A `required_providers` entry with `source` but no version constraint in the same provider block. |
+| `pack-devops-iac-terraform-unpinned-module` | error | `*.tf` | A remote module block without a registry version or immutable Git `ref`. |
+| `pack-devops-iac-k8s-mutable-image-tag` | error | `*.yaml`, `*.yml` | A Kubernetes workload image using the `latest` tag. |
+| `pack-devops-iac-k8s-missing-readiness-probe` | warn | `*.yaml`, `*.yml` | A Deployment, StatefulSet, or DaemonSet with containers but no readiness probe. |
+| `pack-devops-iac-k8s-missing-resource-requests` | warn | `*.yaml`, `*.yml` | A Deployment, StatefulSet, or DaemonSet with containers but no resource requests. |
+| `pack-devops-iac-terraform-apply-without-plan` | error | CI workflow YAML | A workflow invokes `terraform`/`tofu apply` without a plan command or saved-plan input. |
+| `pack-devops-iac-deployment-no-rollback` | warn | deployment/release/runbook Markdown | Deployment instructions with no rollback, roll-back, roll-forward, or rollout-undo path. |
+
+## Layer-2 checks
+
+- Provider/module constraints are compatible with the committed lockfile policy.
+- Plan review names replacements, destroys, environment reach, and irreversible effects.
+- Production promotes the exact artifact tested earlier.
+- Drift detection has an owner and reconciliation path.
+- Rollback accounts for stateful resources, schema compatibility, and verification signals.
+- Rendered manifests are validated when templates or reusable workflows hide final output.
+
+## Heuristic limitations
+
+- HCL checks use brace-local text inspection and do not evaluate expressions.
+- Kubernetes checks inspect complete YAML files, not individual multi-document workload boundaries.
+- CI checks recognize common workflow paths and explicit `plan` commands or plan-file inputs.
+- Markdown rollback checks only target filenames or directories associated with deployments, releases, or runbooks.

--- a/packs/pack-devops-iac/agents/pipeline/validator-rules.md
+++ b/packs/pack-devops-iac/agents/pipeline/validator-rules.md
@@ -26,6 +26,6 @@ Layer-1 static checks implemented in [`scripts/rules.py`](../../scripts/rules.py
 ## Heuristic limitations
 
 - HCL checks use brace-local text inspection and do not evaluate expressions.
-- Kubernetes checks split standard `---` documents and use indentation to scope `containers`; generated templates still require rendered-manifest validation.
-- CI checks inspect each apply independently. They verify an explicit positional plan argument, but cannot prove that an external artifact was reviewed.
+- Kubernetes checks split standard `---` documents and use indentation to scope every direct list item under `containers:`, independent of key order; generated templates still require rendered-manifest validation.
+- CI checks inspect each apply independently, join backslash-continued lines, and exclude shell redirection targets from plan detection. They verify an explicit positional plan argument, but cannot prove that an external artifact was reviewed.
 - Markdown rollback checks only target filenames or directories associated with deployments, releases, or runbooks.

--- a/packs/pack-devops-iac/pack.yaml
+++ b/packs/pack-devops-iac/pack.yaml
@@ -1,0 +1,30 @@
+name: pack-devops-iac
+version: 0.1.0
+description: DevOps and infrastructure-as-code pack — Terraform dependency safety, Kubernetes workload readiness, CI/CD deployment gates, environment promotion, drift control, and rollback readiness.
+
+components:
+  - terraform-safety
+  - kubernetes-workload
+  - ci-cd-release
+  - environment-promotion
+  - infrastructure-drift
+  - rollback-readiness
+
+keywords:
+  terraform-safety: [terraform, opentofu, hcl, provider version, terraform module, infrastructure as code]
+  kubernetes-workload: [kubernetes, k8s, deployment yaml, statefulset, daemonset, helm]
+  ci-cd-release: [ci/cd, pipeline, deployment pipeline, github actions, gitlab ci, release workflow]
+  environment-promotion: [environment promotion, promote to production, staging, production deployment]
+  infrastructure-drift: [infrastructure drift, drift detection, terraform plan, desired state]
+  rollback-readiness: [rollback, roll back, rollout undo, deployment recovery, release recovery]
+
+files:
+  constraints: agents/constraints.md
+  coding_rules: agents/coding-rules.md
+  validator_rules: agents/pipeline/validator-rules.md
+  validator_script: scripts/rules.py
+  retrieval_map: agents/pipeline/retrieval-map.md
+  prompt_overrides: agents/pipeline/prompt-overrides.md
+  common_pitfalls: agents/common-pitfalls.md
+
+conflicts_with: []

--- a/packs/pack-devops-iac/scripts/rules.py
+++ b/packs/pack-devops-iac/scripts/rules.py
@@ -136,7 +136,7 @@ WORKLOAD_KIND = re.compile(
     r"(?m)^\s*kind\s*:\s*(Deployment|StatefulSet|DaemonSet)\s*$"
 )
 CONTAINERS_KEY = re.compile(r"^(\s*)containers\s*:\s*(?:#.*)?$")
-CONTAINER_ITEM = re.compile(r"^(\s*)-\s+(?:name|image)\s*:")
+CONTAINER_ITEM = re.compile(r"^(\s*)-\s*(?:[^#].*)?$")
 IMAGE_VALUE = re.compile(r"^\s*(?:-\s*)?image\s*:\s*([^#]+?)(?:\s+#.*)?$")
 DIGEST_PINNED_IMAGE = re.compile(r"^\S+@sha256:[0-9a-fA-F]{64}$")
 
@@ -283,14 +283,19 @@ def _is_ci_workflow(file_path: Path) -> bool:
     ))
 
 
-APPLY_COMMAND = re.compile(r"\b(terraform|tofu)\s+apply\b([^\n]*)")
+APPLY_COMMAND = re.compile(
+    r"\b(terraform|tofu)\s+apply\b((?:\\\s*\n\s*|[^\n])*)"
+)
 OPTIONS_WITH_SEPARATE_VALUE = {
     "-backup", "-lock-timeout", "-parallelism", "-state", "-state-out",
     "-var", "-var-file",
 }
+REDIRECT_WITH_SEPARATE_TARGET = re.compile(r"^(?:\d*|&)(?:>>?|<<?)$")
+REDIRECT_WITH_INLINE_TARGET = re.compile(r"^(?:\d*|&)(?:>>?|<<?).+$")
 
 
 def _apply_consumes_saved_plan(arguments: str) -> bool:
+    arguments = re.sub(r"\\\s*\n\s*", " ", arguments)
     try:
         tokens = shlex.split(arguments, comments=True)
     except ValueError:
@@ -304,6 +309,11 @@ def _apply_consumes_saved_plan(arguments: str) -> bool:
             break
         if token in OPTIONS_WITH_SEPARATE_VALUE:
             skip_value = True
+            continue
+        if REDIRECT_WITH_SEPARATE_TARGET.match(token):
+            skip_value = True
+            continue
+        if REDIRECT_WITH_INLINE_TARGET.match(token):
             continue
         if token.startswith("-"):
             continue

--- a/packs/pack-devops-iac/scripts/rules.py
+++ b/packs/pack-devops-iac/scripts/rules.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""pack-devops-iac — narrow Layer-1 infrastructure safety validators."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+
+def _vio(rule: str, severity: str, file_path: Path, lineno: int,
+         snippet: str, message: str) -> Dict:
+    return {
+        "rule": rule,
+        "severity": severity,
+        "file": file_path.as_posix(),
+        "line": lineno,
+        "snippet": snippet.strip()[:200],
+        "message": message,
+    }
+
+
+def _brace_block(lines: List[str], start: int) -> Tuple[int, List[str]]:
+    """Return the inclusive end index and lines for a brace-delimited block."""
+    depth = 0
+    opened = False
+    block: List[str] = []
+    for index in range(start, len(lines)):
+        line = lines[index]
+        block.append(line)
+        depth += line.count("{")
+        if "{" in line:
+            opened = True
+        depth -= line.count("}")
+        if opened and depth <= 0:
+            return index, block
+    return len(lines) - 1, block
+
+
+def _assignment_block_start(lines: List[str], source_index: int) -> Optional[int]:
+    for index in range(source_index, max(-1, source_index - 8), -1):
+        if re.match(r"^\s*[A-Za-z0-9_-]+\s*=\s*{\s*$", lines[index]):
+            return index
+        if re.match(r"^\s*required_providers\s*{", lines[index]):
+            break
+    return None
+
+
+def rule_terraform_unpinned_provider(file_path: Path, lines: List[str],
+                                     ctx: Dict) -> List[Dict]:
+    if file_path.suffix.lower() != ".tf":
+        return []
+    text = "\n".join(lines)
+    if not re.search(r"\brequired_providers\s*{", text):
+        return []
+    out = []
+    for index, raw in enumerate(lines):
+        if not re.search(r"\bsource\s*=\s*[\"'][^\"']+[\"']", raw):
+            continue
+        start = _assignment_block_start(lines, index)
+        if start is None:
+            continue
+        _, block = _brace_block(lines, start)
+        if re.search(r"(?m)^\s*version\s*=\s*[\"'][^\"']+[\"']", "\n".join(block)):
+            continue
+        out.append(_vio(
+            "pack-devops-iac-terraform-unpinned-provider", "error",
+            file_path, index + 1, raw,
+            "Terraform provider source has no version constraint in its provider block.",
+        ))
+    return out
+
+
+MODULE_START = re.compile(r'^\s*module\s+[\"\'][^\"\']+[\"\']\s*{')
+SOURCE_VALUE = re.compile(r'(?m)^\s*source\s*=\s*[\"\']([^\"\']+)[\"\']')
+
+
+def rule_terraform_unpinned_module(file_path: Path, lines: List[str],
+                                   ctx: Dict) -> List[Dict]:
+    if file_path.suffix.lower() != ".tf":
+        return []
+    out = []
+    index = 0
+    while index < len(lines):
+        if not MODULE_START.search(lines[index]):
+            index += 1
+            continue
+        end, block_lines = _brace_block(lines, index)
+        block = "\n".join(block_lines)
+        source_match = SOURCE_VALUE.search(block)
+        if source_match:
+            source = source_match.group(1)
+            local = source.startswith(("./", "../"))
+            has_version = bool(re.search(
+                r"(?m)^\s*version\s*=\s*[\"'][^\"']+[\"']", block
+            ))
+            has_git_ref = "?ref=" in source and not re.search(
+                r"[?&]ref=(main|master|head)(?:&|$)", source, re.IGNORECASE
+            )
+            if not local and not has_version and not has_git_ref:
+                source_line = index + next(
+                    (offset for offset, line in enumerate(block_lines)
+                     if SOURCE_VALUE.search(line)), 0
+                )
+                out.append(_vio(
+                    "pack-devops-iac-terraform-unpinned-module", "error",
+                    file_path, source_line + 1, lines[source_line],
+                    f"Remote Terraform module '{source}' is not pinned to a version or immutable ref.",
+                ))
+        index = end + 1
+    return out
+
+
+def _is_yaml(file_path: Path) -> bool:
+    return file_path.suffix.lower() in {".yaml", ".yml"}
+
+
+def _is_k8s_workload(lines: List[str]) -> bool:
+    text = "\n".join(lines)
+    return bool(re.search(
+        r"(?m)^\s*kind\s*:\s*(Deployment|StatefulSet|DaemonSet)\s*$", text
+    )) and bool(re.search(r"(?m)^\s*containers\s*:\s*$", text))
+
+
+LATEST_IMAGE = re.compile(
+    r"^(\s*(?:-\s*)?image\s*:\s*)([\"']?[^\s\"']+:latest[\"']?)(?:\s+#.*)?$",
+    re.IGNORECASE,
+)
+
+
+def rule_k8s_mutable_image_tag(file_path: Path, lines: List[str],
+                                ctx: Dict) -> List[Dict]:
+    if not _is_yaml(file_path) or not _is_k8s_workload(lines):
+        return []
+    out = []
+    for lineno, raw in enumerate(lines, 1):
+        if LATEST_IMAGE.match(raw):
+            out.append(_vio(
+                "pack-devops-iac-k8s-mutable-image-tag", "error",
+                file_path, lineno, raw,
+                "Kubernetes workload uses the mutable 'latest' image tag; use an immutable release tag or digest.",
+            ))
+    return out
+
+
+def rule_k8s_missing_readiness_probe(file_path: Path, lines: List[str],
+                                     ctx: Dict) -> List[Dict]:
+    if not _is_yaml(file_path) or not _is_k8s_workload(lines):
+        return []
+    if re.search(r"(?m)^\s*readinessProbe\s*:\s*$", "\n".join(lines)):
+        return []
+    return [_vio(
+        "pack-devops-iac-k8s-missing-readiness-probe", "warn", file_path, 1,
+        lines[0] if lines else "",
+        "Kubernetes workload has containers but no readinessProbe.",
+    )]
+
+
+def rule_k8s_missing_resource_requests(file_path: Path, lines: List[str],
+                                       ctx: Dict) -> List[Dict]:
+    if not _is_yaml(file_path) or not _is_k8s_workload(lines):
+        return []
+    text = "\n".join(lines)
+    if re.search(r"(?m)^\s*requests\s*:\s*$", text):
+        return []
+    return [_vio(
+        "pack-devops-iac-k8s-missing-resource-requests", "warn", file_path, 1,
+        lines[0] if lines else "",
+        "Kubernetes workload has containers but no resource requests.",
+    )]
+
+
+def _is_ci_workflow(file_path: Path) -> bool:
+    path = file_path.as_posix().lower()
+    return _is_yaml(file_path) and any(marker in path for marker in (
+        "/.github/workflows/", "/.gitlab/", "/ci/", "/pipelines/"
+    ))
+
+
+def rule_terraform_apply_without_plan(file_path: Path, lines: List[str],
+                                      ctx: Dict) -> List[Dict]:
+    if not _is_ci_workflow(file_path):
+        return []
+    text = "\n".join(lines)
+    apply_matches = list(re.finditer(r"\b(terraform|tofu)\s+apply\b([^\n]*)", text))
+    if not apply_matches:
+        return []
+    has_plan_command = bool(re.search(r"\b(terraform|tofu)\s+plan\b", text))
+    has_saved_plan = any(re.search(r"(?:^|\s)[^\s-]+\.tfplan(?:\s|$)", match.group(2))
+                         for match in apply_matches)
+    if has_plan_command or has_saved_plan:
+        return []
+    first = apply_matches[0]
+    lineno = text[:first.start()].count("\n") + 1
+    return [_vio(
+        "pack-devops-iac-terraform-apply-without-plan", "error", file_path,
+        lineno, lines[lineno - 1],
+        "CI workflow applies infrastructure without a plan command or saved plan input.",
+    )]
+
+
+def rule_deployment_no_rollback(file_path: Path, lines: List[str],
+                                ctx: Dict) -> List[Dict]:
+    if file_path.suffix.lower() != ".md":
+        return []
+    path = file_path.as_posix().lower()
+    if not any(marker in path for marker in (
+        "deploy", "release", "/runbooks/", "/runbook/"
+    )):
+        return []
+    text = "\n".join(lines)
+    if not re.search(r"\b(deploy(?:ment)?|release|rollout)\b", text, re.IGNORECASE):
+        return []
+    if re.search(r"\b(rollback|roll\s+back|roll-forward|roll\s+forward|rollout\s+undo)\b",
+                 text, re.IGNORECASE):
+        return []
+    return [_vio(
+        "pack-devops-iac-deployment-no-rollback", "warn", file_path, 1,
+        lines[0] if lines else "",
+        "Deployment/release instructions do not describe a rollback or roll-forward path.",
+    )]
+
+
+RULES = [
+    rule_terraform_unpinned_provider,
+    rule_terraform_unpinned_module,
+    rule_k8s_mutable_image_tag,
+    rule_k8s_missing_readiness_probe,
+    rule_k8s_missing_resource_requests,
+    rule_terraform_apply_without_plan,
+    rule_deployment_no_rollback,
+]

--- a/packs/pack-devops-iac/scripts/rules.py
+++ b/packs/pack-devops-iac/scripts/rules.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import re
+import shlex
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple
 
@@ -38,7 +39,7 @@ def _brace_block(lines: List[str], start: int) -> Tuple[int, List[str]]:
 
 
 def _assignment_block_start(lines: List[str], source_index: int) -> Optional[int]:
-    for index in range(source_index, max(-1, source_index - 8), -1):
+    for index in range(source_index, -1, -1):
         if re.match(r"^\s*[A-Za-z0-9_-]+\s*=\s*{\s*$", lines[index]):
             return index
         if re.match(r"^\s*required_providers\s*{", lines[index]):
@@ -50,29 +51,38 @@ def rule_terraform_unpinned_provider(file_path: Path, lines: List[str],
                                      ctx: Dict) -> List[Dict]:
     if file_path.suffix.lower() != ".tf":
         return []
-    text = "\n".join(lines)
-    if not re.search(r"\brequired_providers\s*{", text):
-        return []
     out = []
-    for index, raw in enumerate(lines):
-        if not re.search(r"\bsource\s*=\s*[\"'][^\"']+[\"']", raw):
+    index = 0
+    while index < len(lines):
+        if not re.search(r"\brequired_providers\s*{", lines[index]):
+            index += 1
             continue
-        start = _assignment_block_start(lines, index)
-        if start is None:
-            continue
-        _, block = _brace_block(lines, start)
-        if re.search(r"(?m)^\s*version\s*=\s*[\"'][^\"']+[\"']", "\n".join(block)):
-            continue
-        out.append(_vio(
-            "pack-devops-iac-terraform-unpinned-provider", "error",
-            file_path, index + 1, raw,
-            "Terraform provider source has no version constraint in its provider block.",
-        ))
+        required_end, required_lines = _brace_block(lines, index)
+        for offset, raw in enumerate(required_lines):
+            if not re.search(r"\bsource\s*=\s*[\"'][^\"']+[\"']", raw):
+                continue
+            start = _assignment_block_start(required_lines, offset)
+            if start is None:
+                continue
+            _, provider_block = _brace_block(required_lines, start)
+            if re.search(
+                r"(?m)^\s*version\s*=\s*[\"'][^\"']+[\"']",
+                "\n".join(provider_block),
+            ):
+                continue
+            source_line = index + offset
+            out.append(_vio(
+                "pack-devops-iac-terraform-unpinned-provider", "error",
+                file_path, source_line + 1, raw,
+                "Terraform provider source has no version constraint in its provider block.",
+            ))
+        index = required_end + 1
     return out
 
 
 MODULE_START = re.compile(r'^\s*module\s+[\"\'][^\"\']+[\"\']\s*{')
 SOURCE_VALUE = re.compile(r'(?m)^\s*source\s*=\s*[\"\']([^\"\']+)[\"\']')
+FULL_COMMIT_REF = re.compile(r"[?&]ref=[0-9a-fA-F]{40}(?:&|$)")
 
 
 def rule_terraform_unpinned_module(file_path: Path, lines: List[str],
@@ -94,10 +104,16 @@ def rule_terraform_unpinned_module(file_path: Path, lines: List[str],
             has_version = bool(re.search(
                 r"(?m)^\s*version\s*=\s*[\"'][^\"']+[\"']", block
             ))
-            has_git_ref = "?ref=" in source and not re.search(
-                r"[?&]ref=(main|master|head)(?:&|$)", source, re.IGNORECASE
+            has_full_commit_ref = bool(FULL_COMMIT_REF.search(source))
+            source_without_query = source.split("?", 1)[0].lower()
+            is_git_source = (
+                source.startswith("git::")
+                or source.startswith(("github.com/", "bitbucket.org/"))
+                or source_without_query.endswith(".git")
             )
-            if not local and not has_version and not has_git_ref:
+            dependency_is_pinned = (has_full_commit_ref if is_git_source
+                                    else has_version)
+            if not local and not dependency_is_pinned:
                 source_line = index + next(
                     (offset for offset, line in enumerate(block_lines)
                      if SOURCE_VALUE.search(line)), 0
@@ -105,7 +121,7 @@ def rule_terraform_unpinned_module(file_path: Path, lines: List[str],
                 out.append(_vio(
                     "pack-devops-iac-terraform-unpinned-module", "error",
                     file_path, source_line + 1, lines[source_line],
-                    f"Remote Terraform module '{source}' is not pinned to a version or immutable ref.",
+                    f"Remote Terraform module '{source}' is not pinned to a registry version or full Git commit SHA.",
                 ))
         index = end + 1
     return out
@@ -115,59 +131,149 @@ def _is_yaml(file_path: Path) -> bool:
     return file_path.suffix.lower() in {".yaml", ".yml"}
 
 
-def _is_k8s_workload(lines: List[str]) -> bool:
-    text = "\n".join(lines)
-    return bool(re.search(
-        r"(?m)^\s*kind\s*:\s*(Deployment|StatefulSet|DaemonSet)\s*$", text
-    )) and bool(re.search(r"(?m)^\s*containers\s*:\s*$", text))
-
-
-LATEST_IMAGE = re.compile(
-    r"^(\s*(?:-\s*)?image\s*:\s*)([\"']?[^\s\"']+:latest[\"']?)(?:\s+#.*)?$",
-    re.IGNORECASE,
+YAML_DOCUMENT_SEPARATOR = re.compile(r"^\s*---(?:\s+#.*)?\s*$")
+WORKLOAD_KIND = re.compile(
+    r"(?m)^\s*kind\s*:\s*(Deployment|StatefulSet|DaemonSet)\s*$"
 )
+CONTAINERS_KEY = re.compile(r"^(\s*)containers\s*:\s*(?:#.*)?$")
+CONTAINER_ITEM = re.compile(r"^(\s*)-\s+(?:name|image)\s*:")
+IMAGE_VALUE = re.compile(r"^\s*(?:-\s*)?image\s*:\s*([^#]+?)(?:\s+#.*)?$")
+DIGEST_PINNED_IMAGE = re.compile(r"^\S+@sha256:[0-9a-fA-F]{64}$")
 
 
-def rule_k8s_mutable_image_tag(file_path: Path, lines: List[str],
-                                ctx: Dict) -> List[Dict]:
-    if not _is_yaml(file_path) or not _is_k8s_workload(lines):
+def _indent(line: str) -> int:
+    return len(line) - len(line.lstrip(" "))
+
+
+def _yaml_documents(lines: List[str]) -> List[Tuple[int, List[str]]]:
+    documents = []
+    start = 0
+    for index, raw in enumerate(lines):
+        if not YAML_DOCUMENT_SEPARATOR.match(raw):
+            continue
+        if any(line.strip() for line in lines[start:index]):
+            documents.append((start, lines[start:index]))
+        start = index + 1
+    if any(line.strip() for line in lines[start:]):
+        documents.append((start, lines[start:]))
+    return documents
+
+
+def _workload_containers(lines: List[str]) -> List[Tuple[int, str, List[str]]]:
+    """Return (zero-based line, display name, block) per workload container."""
+    containers = []
+    for document_start, document in _yaml_documents(lines):
+        if not WORKLOAD_KIND.search("\n".join(document)):
+            continue
+        for section_index, raw in enumerate(document):
+            section_match = CONTAINERS_KEY.match(raw)
+            if not section_match:
+                continue
+            section_indent = len(section_match.group(1))
+            section_end = len(document)
+            for index in range(section_index + 1, len(document)):
+                candidate = document[index]
+                if not candidate.strip() or candidate.lstrip().startswith("#"):
+                    continue
+                if _indent(candidate) <= section_indent:
+                    section_end = index
+                    break
+
+            item_indent = None
+            item_starts = []
+            for index in range(section_index + 1, section_end):
+                item_match = CONTAINER_ITEM.match(document[index])
+                if not item_match:
+                    continue
+                indent = len(item_match.group(1))
+                if item_indent is None:
+                    item_indent = indent
+                if indent == item_indent:
+                    item_starts.append(index)
+
+            for position, item_start in enumerate(item_starts):
+                item_end = (item_starts[position + 1]
+                            if position + 1 < len(item_starts) else section_end)
+                block = document[item_start:item_end]
+                name = "<unnamed>"
+                for block_line in block:
+                    name_match = re.match(
+                        r"^\s*(?:-\s*)?name\s*:\s*[\"']?([^\s\"'#]+)",
+                        block_line,
+                    )
+                    if name_match:
+                        name = name_match.group(1)
+                        break
+                containers.append((document_start + item_start, name, block))
+    return containers
+
+
+def _has_resource_requests(block: List[str]) -> bool:
+    for index, raw in enumerate(block):
+        if not re.match(r"^\s*resources\s*:\s*(?:#.*)?$", raw):
+            continue
+        resources_indent = _indent(raw)
+        for nested in block[index + 1:]:
+            if not nested.strip() or nested.lstrip().startswith("#"):
+                continue
+            if _indent(nested) <= resources_indent:
+                break
+            if re.match(r"^\s*requests\s*:\s*(?:#.*)?$", nested):
+                return True
+    return False
+
+
+def rule_k8s_image_not_digest_pinned(file_path: Path, lines: List[str],
+                                     ctx: Dict) -> List[Dict]:
+    if not _is_yaml(file_path):
         return []
     out = []
-    for lineno, raw in enumerate(lines, 1):
-        if LATEST_IMAGE.match(raw):
+    for start, name, block in _workload_containers(lines):
+        for offset, raw in enumerate(block):
+            image_match = IMAGE_VALUE.match(raw)
+            if not image_match:
+                continue
+            image = image_match.group(1).strip().strip("\"'")
+            if DIGEST_PINNED_IMAGE.match(image):
+                continue
             out.append(_vio(
-                "pack-devops-iac-k8s-mutable-image-tag", "error",
-                file_path, lineno, raw,
-                "Kubernetes workload uses the mutable 'latest' image tag; use an immutable release tag or digest.",
+                "pack-devops-iac-k8s-image-not-digest-pinned", "error",
+                file_path, start + offset + 1, raw,
+                f"Kubernetes container '{name}' image is not pinned by sha256 digest.",
             ))
     return out
 
 
 def rule_k8s_missing_readiness_probe(file_path: Path, lines: List[str],
                                      ctx: Dict) -> List[Dict]:
-    if not _is_yaml(file_path) or not _is_k8s_workload(lines):
+    if not _is_yaml(file_path):
         return []
-    if re.search(r"(?m)^\s*readinessProbe\s*:\s*$", "\n".join(lines)):
-        return []
-    return [_vio(
-        "pack-devops-iac-k8s-missing-readiness-probe", "warn", file_path, 1,
-        lines[0] if lines else "",
-        "Kubernetes workload has containers but no readinessProbe.",
-    )]
+    out = []
+    for start, name, block in _workload_containers(lines):
+        if re.search(r"(?m)^\s*readinessProbe\s*:\s*$", "\n".join(block)):
+            continue
+        out.append(_vio(
+            "pack-devops-iac-k8s-missing-readiness-probe", "warn",
+            file_path, start + 1, block[0],
+            f"Kubernetes container '{name}' has no readinessProbe.",
+        ))
+    return out
 
 
 def rule_k8s_missing_resource_requests(file_path: Path, lines: List[str],
                                        ctx: Dict) -> List[Dict]:
-    if not _is_yaml(file_path) or not _is_k8s_workload(lines):
+    if not _is_yaml(file_path):
         return []
-    text = "\n".join(lines)
-    if re.search(r"(?m)^\s*requests\s*:\s*$", text):
-        return []
-    return [_vio(
-        "pack-devops-iac-k8s-missing-resource-requests", "warn", file_path, 1,
-        lines[0] if lines else "",
-        "Kubernetes workload has containers but no resource requests.",
-    )]
+    out = []
+    for start, name, block in _workload_containers(lines):
+        if _has_resource_requests(block):
+            continue
+        out.append(_vio(
+            "pack-devops-iac-k8s-missing-resource-requests", "warn",
+            file_path, start + 1, block[0],
+            f"Kubernetes container '{name}' has no resource requests.",
+        ))
+    return out
 
 
 def _is_ci_workflow(file_path: Path) -> bool:
@@ -177,26 +283,50 @@ def _is_ci_workflow(file_path: Path) -> bool:
     ))
 
 
-def rule_terraform_apply_without_plan(file_path: Path, lines: List[str],
-                                      ctx: Dict) -> List[Dict]:
+APPLY_COMMAND = re.compile(r"\b(terraform|tofu)\s+apply\b([^\n]*)")
+OPTIONS_WITH_SEPARATE_VALUE = {
+    "-backup", "-lock-timeout", "-parallelism", "-state", "-state-out",
+    "-var", "-var-file",
+}
+
+
+def _apply_consumes_saved_plan(arguments: str) -> bool:
+    try:
+        tokens = shlex.split(arguments, comments=True)
+    except ValueError:
+        return False
+    skip_value = False
+    for token in tokens:
+        if skip_value:
+            skip_value = False
+            continue
+        if token in {"&&", "||", ";", "|"}:
+            break
+        if token in OPTIONS_WITH_SEPARATE_VALUE:
+            skip_value = True
+            continue
+        if token.startswith("-"):
+            continue
+        return True
+    return False
+
+
+def rule_terraform_apply_without_saved_plan(file_path: Path, lines: List[str],
+                                            ctx: Dict) -> List[Dict]:
     if not _is_ci_workflow(file_path):
         return []
     text = "\n".join(lines)
-    apply_matches = list(re.finditer(r"\b(terraform|tofu)\s+apply\b([^\n]*)", text))
-    if not apply_matches:
-        return []
-    has_plan_command = bool(re.search(r"\b(terraform|tofu)\s+plan\b", text))
-    has_saved_plan = any(re.search(r"(?:^|\s)[^\s-]+\.tfplan(?:\s|$)", match.group(2))
-                         for match in apply_matches)
-    if has_plan_command or has_saved_plan:
-        return []
-    first = apply_matches[0]
-    lineno = text[:first.start()].count("\n") + 1
-    return [_vio(
-        "pack-devops-iac-terraform-apply-without-plan", "error", file_path,
-        lineno, lines[lineno - 1],
-        "CI workflow applies infrastructure without a plan command or saved plan input.",
-    )]
+    out = []
+    for match in APPLY_COMMAND.finditer(text):
+        if _apply_consumes_saved_plan(match.group(2)):
+            continue
+        lineno = text[:match.start()].count("\n") + 1
+        out.append(_vio(
+            "pack-devops-iac-terraform-apply-without-saved-plan", "error",
+            file_path, lineno, lines[lineno - 1],
+            "CI apply command does not consume an explicit saved plan argument.",
+        ))
+    return out
 
 
 def rule_deployment_no_rollback(file_path: Path, lines: List[str],
@@ -224,9 +354,9 @@ def rule_deployment_no_rollback(file_path: Path, lines: List[str],
 RULES = [
     rule_terraform_unpinned_provider,
     rule_terraform_unpinned_module,
-    rule_k8s_mutable_image_tag,
+    rule_k8s_image_not_digest_pinned,
     rule_k8s_missing_readiness_probe,
     rule_k8s_missing_resource_requests,
-    rule_terraform_apply_without_plan,
+    rule_terraform_apply_without_saved_plan,
     rule_deployment_no_rollback,
 ]

--- a/scripts/test_contextd_runtime.py
+++ b/scripts/test_contextd_runtime.py
@@ -31,6 +31,7 @@ import contextd_version  # noqa: E402
 import generate_manifest  # noqa: E402
 import cmd_resolve  # noqa: E402
 import render_runtime  # noqa: E402
+import test_pack_devops_iac  # noqa: E402
 from lib import contextd_resolver, pack_validation, task_context_engine  # noqa: E402
 
 
@@ -1342,6 +1343,7 @@ def run() -> int:
         test_doctor_and_adapter_drift_checks,
         test_codex_agents_use_json_canonical_artifact,
         test_pack_ui_ux_rules,
+        test_pack_devops_iac.test_pack_devops_iac_rules,
         test_stdio_utf8_under_legacy_codepage,
         test_intent_classification_word_boundaries,
         test_pack_keyword_special_chars,

--- a/scripts/test_pack_devops_iac.py
+++ b/scripts/test_pack_devops_iac.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Focused positive and negative tests for pack-devops-iac validators."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent.parent
+RULES_PATH = ROOT / "packs" / "pack-devops-iac" / "scripts" / "rules.py"
+
+
+def _load_rules():
+    spec = importlib.util.spec_from_file_location("pack_devops_iac_rules_test", RULES_PATH)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module.RULES
+
+
+def _violations(rules, file_path: str, content: str) -> list[dict]:
+    out = []
+    lines = content.strip().splitlines()
+    for rule in rules:
+        out.extend(rule(Path(file_path), lines, {}))
+    return out
+
+
+def test_pack_devops_iac_rules() -> None:
+    rules = _load_rules()
+
+    terraform_bad = _violations(rules, "/tmp/main.tf", '''
+terraform {
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
+  }
+}
+module "network" {
+  source = "git::https://example.test/network.git"
+}
+''')
+    terraform_rule_ids = {item["rule"] for item in terraform_bad}
+    assert "pack-devops-iac-terraform-unpinned-provider" in terraform_rule_ids
+    assert "pack-devops-iac-terraform-unpinned-module" in terraform_rule_ids
+
+    workload_bad = _violations(rules, "/tmp/deployment.yaml", '''
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          image: registry.example/api:latest
+''')
+    workload_rule_ids = {item["rule"] for item in workload_bad}
+    assert "pack-devops-iac-k8s-mutable-image-tag" in workload_rule_ids
+    assert "pack-devops-iac-k8s-missing-readiness-probe" in workload_rule_ids
+    assert "pack-devops-iac-k8s-missing-resource-requests" in workload_rule_ids
+
+    workflow_bad = _violations(rules, "/tmp/repo/.github/workflows/deploy.yml", '''
+name: deploy
+jobs:
+  apply:
+    steps:
+      - run: terraform apply -auto-approve
+''')
+    assert any(item["rule"] == "pack-devops-iac-terraform-apply-without-plan"
+               for item in workflow_bad)
+
+    runbook_bad = _violations(
+        rules, "/tmp/workspaces/default/runbooks/deploy-api.md", '''
+# API deployment
+Run the release workflow and verify the health dashboard.
+''')
+    assert any(item["rule"] == "pack-devops-iac-deployment-no-rollback"
+               for item in runbook_bad)
+
+    clean_cases = [
+        ("/tmp/main.tf", '''
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+module "network" {
+  source = "git::https://example.test/network.git?ref=v1.2.3"
+}
+'''),
+        ("/tmp/deployment.yaml", '''
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          image: registry.example/api:v1.2.3
+          readinessProbe:
+            httpGet:
+              path: /ready
+              port: 8080
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+'''),
+        ("/tmp/repo/.github/workflows/deploy.yml", '''
+name: deploy
+jobs:
+  apply:
+    steps:
+      - run: terraform plan -out=reviewed.tfplan
+      - run: terraform apply reviewed.tfplan
+'''),
+        ("/tmp/workspaces/default/runbooks/deploy-api.md", '''
+# API deployment
+Deploy the release, verify readiness, and rollback with rollout undo on failure.
+'''),
+    ]
+    for file_path, content in clean_cases:
+        assert not _violations(rules, file_path, content), file_path
+
+
+if __name__ == "__main__":
+    test_pack_devops_iac_rules()
+    print("All pack-devops-iac tests passed")

--- a/scripts/test_pack_devops_iac.py
+++ b/scripts/test_pack_devops_iac.py
@@ -140,6 +140,39 @@ jobs:
     ), saved_plan
 
 
+    redirection_only = _violations(
+        rules, "/tmp/repo/.github/workflows/deploy.yml", '''
+name: deploy
+jobs:
+  deploy:
+    steps:
+      - run: terraform apply > apply.log
+      - run: tofu apply 2>errors.log
+''')
+    assert len(_by_rule(
+        redirection_only,
+        "pack-devops-iac-terraform-apply-without-saved-plan",
+    )) == 2, redirection_only
+
+    multiline = _violations(
+        rules, "/tmp/repo/.github/workflows/deploy.yml", '''
+name: deploy
+jobs:
+  deploy:
+    steps:
+      - run: |
+          terraform apply \\
+            reviewed.tfplan
+      - run: |
+          tofu apply \\
+            -auto-approve > apply.log
+''')
+    assert len(_by_rule(
+        multiline,
+        "pack-devops-iac-terraform-apply-without-saved-plan",
+    )) == 1, multiline
+
+
 def _test_k8s_per_document_and_container(rules) -> None:
     multi_document = _violations(rules, "/tmp/workloads.yaml", '''
 apiVersion: apps/v1
@@ -183,6 +216,32 @@ spec:
     assert not _by_rule(
         multi_document, "pack-devops-iac-k8s-image-not-digest-pinned"
     ), multi_document
+
+
+    key_order = _violations(rules, "/tmp/security-first.yaml", '''
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: security-first
+spec:
+  template:
+    spec:
+      containers:
+        - securityContext:
+            runAsNonRoot: true
+          name: api
+          image: registry.example/api:latest
+''')
+    assert len(_by_rule(
+        key_order, "pack-devops-iac-k8s-image-not-digest-pinned"
+    )) == 1, key_order
+    assert len(_by_rule(
+        key_order, "pack-devops-iac-k8s-missing-readiness-probe"
+    )) == 1, key_order
+    assert len(_by_rule(
+        key_order, "pack-devops-iac-k8s-missing-resource-requests"
+    )) == 1, key_order
+    assert all("'api'" in item["message"] for item in key_order), key_order
 
 
 def _test_k8s_digest_pinning(rules) -> None:

--- a/scripts/test_pack_devops_iac.py
+++ b/scripts/test_pack_devops_iac.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Focused positive and negative tests for pack-devops-iac validators."""
+"""Focused regression tests for pack-devops-iac validators."""
 
 from __future__ import annotations
 
@@ -27,10 +27,12 @@ def _violations(rules, file_path: str, content: str) -> list[dict]:
     return out
 
 
-def test_pack_devops_iac_rules() -> None:
-    rules = _load_rules()
+def _by_rule(violations: list[dict], rule_id: str) -> list[dict]:
+    return [item for item in violations if item["rule"] == rule_id]
 
-    terraform_bad = _violations(rules, "/tmp/main.tf", '''
+
+def _test_terraform_dependency_pinning(rules) -> None:
+    bad = _violations(rules, "/tmp/main.tf", '''
 terraform {
   required_providers {
     aws = {
@@ -38,51 +40,25 @@ terraform {
     }
   }
 }
-module "network" {
-  source = "git::https://example.test/network.git"
+module "unversioned" {
+  source = "git::https://example.test/unversioned.git"
+}
+module "develop_branch" {
+  source = "git::https://example.test/develop.git?ref=develop"
+  version = "1.0.0"
+}
+module "feature_branch" {
+  source = "git::https://example.test/feature.git?ref=feature/foo"
 }
 ''')
-    terraform_rule_ids = {item["rule"] for item in terraform_bad}
-    assert "pack-devops-iac-terraform-unpinned-provider" in terraform_rule_ids
-    assert "pack-devops-iac-terraform-unpinned-module" in terraform_rule_ids
+    assert len(_by_rule(
+        bad, "pack-devops-iac-terraform-unpinned-provider"
+    )) == 1, bad
+    assert len(_by_rule(
+        bad, "pack-devops-iac-terraform-unpinned-module"
+    )) == 3, bad
 
-    workload_bad = _violations(rules, "/tmp/deployment.yaml", '''
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: api
-spec:
-  template:
-    spec:
-      containers:
-        - name: api
-          image: registry.example/api:latest
-''')
-    workload_rule_ids = {item["rule"] for item in workload_bad}
-    assert "pack-devops-iac-k8s-mutable-image-tag" in workload_rule_ids
-    assert "pack-devops-iac-k8s-missing-readiness-probe" in workload_rule_ids
-    assert "pack-devops-iac-k8s-missing-resource-requests" in workload_rule_ids
-
-    workflow_bad = _violations(rules, "/tmp/repo/.github/workflows/deploy.yml", '''
-name: deploy
-jobs:
-  apply:
-    steps:
-      - run: terraform apply -auto-approve
-''')
-    assert any(item["rule"] == "pack-devops-iac-terraform-apply-without-plan"
-               for item in workflow_bad)
-
-    runbook_bad = _violations(
-        rules, "/tmp/workspaces/default/runbooks/deploy-api.md", '''
-# API deployment
-Run the release workflow and verify the health dashboard.
-''')
-    assert any(item["rule"] == "pack-devops-iac-deployment-no-rollback"
-               for item in runbook_bad)
-
-    clean_cases = [
-        ("/tmp/main.tf", '''
+    clean = _violations(rules, "/tmp/main.tf", '''
 terraform {
   required_providers {
     aws = {
@@ -91,11 +67,81 @@ terraform {
     }
   }
 }
-module "network" {
-  source = "git::https://example.test/network.git?ref=v1.2.3"
+module "registry" {
+  source  = "hashicorp/consul/aws"
+  version = "0.11.0"
 }
-'''),
-        ("/tmp/deployment.yaml", '''
+module "git_commit" {
+  source = "git::https://example.test/network.git?ref=0123456789abcdef0123456789abcdef01234567"
+}
+module "local" {
+  source = "./modules/local"
+}
+''')
+    assert not clean, clean
+
+
+def _test_apply_consumes_saved_plan(rules) -> None:
+    plan_but_fresh_apply = _violations(
+        rules, "/tmp/repo/.github/workflows/deploy.yml", '''
+name: deploy
+jobs:
+  deploy:
+    steps:
+      - run: terraform plan -out=reviewed.tfplan
+      - run: terraform apply -auto-approve
+''')
+    assert len(_by_rule(
+        plan_but_fresh_apply,
+        "pack-devops-iac-terraform-apply-without-saved-plan",
+    )) == 1, plan_but_fresh_apply
+
+    unrelated_jobs = _violations(
+        rules, "/tmp/repo/.github/workflows/deploy.yml", '''
+name: deploy
+jobs:
+  preview:
+    steps:
+      - run: terraform plan -out=preview.tfplan
+  production:
+    steps:
+      - run: terraform apply -auto-approve
+''')
+    assert len(_by_rule(
+        unrelated_jobs,
+        "pack-devops-iac-terraform-apply-without-saved-plan",
+    )) == 1, unrelated_jobs
+
+    mixed_applies = _violations(
+        rules, "/tmp/repo/.github/workflows/deploy.yml", '''
+name: deploy
+jobs:
+  deploy:
+    steps:
+      - run: terraform apply reviewed.tfplan
+      - run: tofu apply -auto-approve
+''')
+    assert len(_by_rule(
+        mixed_applies,
+        "pack-devops-iac-terraform-apply-without-saved-plan",
+    )) == 1, mixed_applies
+
+    saved_plan = _violations(
+        rules, "/tmp/repo/.github/workflows/deploy.yml", '''
+name: deploy
+jobs:
+  deploy:
+    steps:
+      - run: terraform apply reviewed.tfplan
+      - run: tofu apply "$PLAN_FILE"
+''')
+    assert not _by_rule(
+        saved_plan, "pack-devops-iac-terraform-apply-without-saved-plan"
+    ), saved_plan
+
+
+def _test_k8s_per_document_and_container(rules) -> None:
+    multi_document = _violations(rules, "/tmp/workloads.yaml", '''
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -105,7 +151,7 @@ spec:
     spec:
       containers:
         - name: api
-          image: registry.example/api:v1.2.3
+          image: registry.example/api@sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
           readinessProbe:
             httpGet:
               path: /ready
@@ -114,22 +160,100 @@ spec:
             requests:
               cpu: 100m
               memory: 128Mi
-'''),
-        ("/tmp/repo/.github/workflows/deploy.yml", '''
-name: deploy
-jobs:
-  apply:
-    steps:
-      - run: terraform plan -out=reviewed.tfplan
-      - run: terraform apply reviewed.tfplan
-'''),
-        ("/tmp/workspaces/default/runbooks/deploy-api.md", '''
+        - name: sidecar
+          image: registry.example/sidecar@sha256:1123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: worker
+spec:
+  template:
+    spec:
+      containers:
+        - name: worker
+          image: registry.example/worker@sha256:2123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+''')
+    assert len(_by_rule(
+        multi_document, "pack-devops-iac-k8s-missing-readiness-probe"
+    )) == 2, multi_document
+    assert len(_by_rule(
+        multi_document, "pack-devops-iac-k8s-missing-resource-requests"
+    )) == 2, multi_document
+    assert not _by_rule(
+        multi_document, "pack-devops-iac-k8s-image-not-digest-pinned"
+    ), multi_document
+
+
+def _test_k8s_digest_pinning(rules) -> None:
+    images = _violations(rules, "/tmp/deployment.yaml", '''
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: image-cases
+spec:
+  template:
+    spec:
+      containers:
+        - name: untagged
+          image: registry.example/api
+          readinessProbe: {}
+          resources:
+            requests: {}
+        - name: stable
+          image: registry.example/api:stable
+          readinessProbe: {}
+          resources:
+            requests: {}
+        - name: semver
+          image: registry.example/api:v1.2.3
+          readinessProbe: {}
+          resources:
+            requests: {}
+        - name: digest
+          image: registry.example/api@sha256:3123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+          readinessProbe: {}
+          resources:
+            requests: {}
+''')
+    image_violations = _by_rule(
+        images, "pack-devops-iac-k8s-image-not-digest-pinned"
+    )
+    assert len(image_violations) == 3, images
+    messages = "\n".join(item["message"] for item in image_violations)
+    assert "untagged" in messages
+    assert "stable" in messages
+    assert "semver" in messages
+    assert "container 'digest'" not in messages
+
+
+def _test_deployment_rollback(rules) -> None:
+    bad = _violations(
+        rules, "/tmp/workspaces/default/runbooks/deploy-api.md", '''
+# API deployment
+Run the release workflow and verify the health dashboard.
+''')
+    assert len(_by_rule(
+        bad, "pack-devops-iac-deployment-no-rollback"
+    )) == 1, bad
+
+    clean = _violations(
+        rules, "/tmp/workspaces/default/runbooks/deploy-api.md", '''
 # API deployment
 Deploy the release, verify readiness, and rollback with rollout undo on failure.
-'''),
-    ]
-    for file_path, content in clean_cases:
-        assert not _violations(rules, file_path, content), file_path
+''')
+    assert not _by_rule(
+        clean, "pack-devops-iac-deployment-no-rollback"
+    ), clean
+
+
+def test_pack_devops_iac_rules() -> None:
+    rules = _load_rules()
+    _test_terraform_dependency_pinning(rules)
+    _test_apply_consumes_saved_plan(rules)
+    _test_k8s_per_document_and_container(rules)
+    _test_k8s_digest_pinning(rules)
+    _test_deployment_rollback(rules)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary / Context

Adds pack-devops-iac v0.1 for Terraform/OpenTofu dependency safety, Kubernetes workload readiness, CI/CD plan gates, environment promotion, drift ownership, and rollback readiness.

The pack includes the full manifest/docs/retrieval/prompt structure, seven narrow Layer-1 validators, ten common pitfalls, focused positive/negative tests, catalog registration, and regenerated release metadata.

## Problem & Why

Infrastructure changes need context beyond generic backend and security guidance. The existing roadmap called out pack-devops-iac, but no pack encoded deterministic infrastructure change and deployment safety rules.

The implementation keeps security, performance, and database responsibilities in their existing packs. Higher-judgment concerns such as blast radius, artifact promotion, and drift ownership remain Layer-2 self-checks instead of unreliable regex gates.

## Test Notes

- [x] python scripts/test_lint_wiki.py
- [x] python scripts/test_atomic_write.py
- [x] python scripts/test_detect_repetition.py
- [x] python scripts/lint-wiki.py --all-workspaces --wiki-root .
- [x] python scripts/test_contextd_runtime.py (34 passed)
- [x] python scripts/test_pack_devops_iac.py
- [x] python scripts/cli.py pack-validate --all --format text (15 packs, 0 errors, 0 warnings)

## Related Issues

No linked issue; implements the pack-devops-iac item listed in the pack roadmap.

## Docs / Workflow Impact

- [x] Updated docs because behavior/workflow changed
- [ ] No docs update needed

Adds an opt-in pack only. Existing workspaces are unchanged until they enable pack-devops-iac.

## Wiki-specific checks

- [x] Preserved workspace isolation
- [x] No cross-workspace knowledge mixing
- [x] Avoided duplicate docs/patterns

## Project Spirit Check

- [x] Change reinforces knowledge-first workflow (contracts/patterns before invention)
- [x] Contributor experience stays simple and practical (no unnecessary complexity)
- [x] Project voice and intent remain consistent across docs/workflows
- [x] Trade-offs are documented in the pack heuristic limitations and validator catalog
