### PR TITLE
feat(okf): standardize wiki markdown with OKF v0.2 frontmatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ Knowledge files in `workspaces/{ws}/` follow [OKF v0.2](https://github.com/Googl
 - **Write new concepts from templates** in [templates/](templates/) — they already carry the OKF fields; just fill them in.
 - **Trust is derived, not claimed**: `status: draft | stable | deprecated`; `verified` by a `human:` actor outranks process-only confirmation.
 - **Index and config files are the exception** (`README.md`, `INDEX.md`, `_index.md`, `patterns-index.md`, `workspace.md`) — they are navigation, not concepts, so no frontmatter is required.
-- **The linter keeps you honest**: `python scripts/lint-wiki.py` warns on missing/unknown `type`, bad `status`, and unreferenced `sources[].id` — warnings, never blocks, per OKF's "tolerate unknown" stance.
+- **The linter keeps you honest**: `python scripts/lint-wiki.py` warns on missing/unknown `type`, bad `status`, and unreferenced `sources[].id` — warnings never fail the run (exit 0), per OKF's "tolerate unknown" stance; pass `--strict` for warnings-as-errors.
 
 Full mapping, type set, and enforcement rules: [docs/wiki-reference.md#okf-open-knowledge-format](docs/wiki-reference.md).
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,28 @@ contextd/
 
 Legacy `<project>/.claude/wiki.json` and `<project>/.Codex/wiki.json` are read as adapters during the migration window. They are not the source of truth.
 
+## OKF (Open Knowledge Format)
+
+Knowledge files in `workspaces/{ws}/` follow [OKF v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) — an open, human- and agent-friendly format for knowledge metadata. Every concept file (pattern, contract, decision, runbook, ...) carries a small YAML frontmatter with `type` (required) plus `title`/`description`/`status`/provenance (recommended).
+
+**Why OKF**:
+
+- Agents and tools can parse, filter, and route on `type` without bespoke SDKs or regex over headings.
+- Provenance is first-class: `generated: {by, at}`, `verified: [{by, at}]` record who produced and confirmed a concept — trust becomes traceable, not assumed.
+- Diffable in version control, portable across tools and organizations, with no registry or central authority.
+- Before OKF, frontmatter keys were ad-hoc (`name`, `slug`, `owner`, `source_type`, ...) — the same concept was described differently in every file.
+
+**Mental model when using it**:
+
+- **Frontmatter = metadata, body = knowledge.** The body stays plain markdown for humans; the frontmatter is the machine-readable handle.
+- **Every concept file answers three questions**: what kind of thing is this (`type`), what is it (`title`/`description`), and how trustworthy is it (`status` + provenance). If a file can't answer them, it isn't a concept file yet.
+- **Write new concepts from templates** in [templates/](templates/) — they already carry the OKF fields; just fill them in.
+- **Trust is derived, not claimed**: `status: draft | stable | deprecated`; `verified` by a `human:` actor outranks process-only confirmation.
+- **Index and config files are the exception** (`README.md`, `INDEX.md`, `_index.md`, `patterns-index.md`, `workspace.md`) — they are navigation, not concepts, so no frontmatter is required.
+- **The linter keeps you honest**: `python scripts/lint-wiki.py` warns on missing/unknown `type`, bad `status`, and unreferenced `sources[].id` — warnings, never blocks, per OKF's "tolerate unknown" stance.
+
+Full mapping, type set, and enforcement rules: [docs/wiki-reference.md#okf-open-knowledge-format](docs/wiki-reference.md).
+
 ## Packs (Stack-specific Knowledge)
 
 Packs are stack/use-case knowledge layers between engine and workspace:

--- a/docs/wiki-reference.md
+++ b/docs/wiki-reference.md
@@ -103,6 +103,33 @@ When code changes, update the wiki of the **active workspace**. Keep both in syn
 
 Use templates in [templates/](../templates/).
 
+## OKF (Open Knowledge Format)
+
+Concept files trong workspace theo [OKF v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md): YAML frontmatter bắt buộc `type`, khuyến nghị `title`/`description`. Mục đích: metadata đồng nhất để agent/tool parse, provenance (ai tạo, verified bởi ai) traceable, diffable trong version control.
+
+**Type set hiện tại** (lint warning nếu type ngoài set): `Contract`, `Pattern`, `Decision`, `Evidence`, `Runbook`, `Report`, `Tool`, `Service`, `Domain`, `Reference`, `Recipe`.
+
+**Field mapping contextd → OKF:**
+
+| contextd | OKF |
+|----------|-----|
+| `{ws}/platform/contracts/*.md` | `type: Contract` |
+| `{ws}/platform/patterns/*.md` | `type: Pattern` |
+| `{ws}/decisions/*.md` | `type: Decision`, `status: stable` khi ACCEPTED (OKF status = lifecycle; ADR Status trong body giữ nguyên) |
+| `{ws}/runbooks/*.md` | `type: Runbook` |
+| `{ws}/evidence/qa/*/...` | `type: Evidence` + `generated: { by, at }` |
+| `agents/*.md` (engine rules) | `type: Reference` (khi áp dụng) |
+| `patterns-index.md`, `README.md`, `INDEX.md`, `_index.md` | index role — KHÔNG cần frontmatter (OKF reserve `index.md`/`log.md`; project giữ tên riêng) |
+
+**Quy tắc:**
+
+- `status` ∈ `draft | stable | deprecated` (absent ⇒ `stable`). Tool-spec dùng lifecycle riêng (`draft|specced|building|done|shelved` — pack constraint, không đổi).
+- Provenance: `generated: { by: <actor>, at: <ISO> }`, `verified: [{ by, at }]`, actor convention `human:<id>` / `process:<id>` / `<agent>/<version>`.
+- Per-claim attribution: footnote `[^id]` trong body, `id` join vào `sources[].id`.
+- Consumers KHÔNG reject unknown keys/types — OKF "tolerate unknown" (lint chỉ warning).
+
+**Enforcement**: `scripts/lint-wiki.py` check frontmatter parseable, `type` non-empty, type ∈ set, `status` ∈ enum, `sources[].id` có footnote tương ứng — tất cả warning (exit 2). File ngoài concept (index/config) và `.claude/**` (harness schema riêng) không bị check.
+
 ## Detailed References
 
 | Topic | File |

--- a/docs/wiki-reference.md
+++ b/docs/wiki-reference.md
@@ -128,7 +128,7 @@ Concept files trong workspace theo [OKF v0.2](https://github.com/GoogleCloudPlat
 - Per-claim attribution: footnote `[^id]` trong body, `id` join vào `sources[].id`.
 - Consumers KHÔNG reject unknown keys/types — OKF "tolerate unknown" (lint chỉ warning).
 
-**Enforcement**: `scripts/lint-wiki.py` check frontmatter parseable, `type` non-empty, type ∈ set, `status` ∈ enum, `sources[].id` có footnote tương ứng — tất cả warning (exit 2). File ngoài concept (index/config) và `.claude/**` (harness schema riêng) không bị check.
+**Enforcement**: `scripts/lint-wiki.py` check frontmatter parseable, `type` non-empty, type ∈ set, `status` ∈ enum, `sources[].id` có footnote tương ứng — tất cả warning, **exit 0 mặc định** (CI-friendly; `--strict` → exit 2 nếu muốn warnings-as-errors). File ngoài concept (index/config) và `.claude/**` (harness schema riêng) không bị check.
 
 ## Detailed References
 

--- a/docs/wiki-reference.md
+++ b/docs/wiki-reference.md
@@ -107,7 +107,7 @@ Use templates in [templates/](../templates/).
 
 Concept files trong workspace theo [OKF v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md): YAML frontmatter bắt buộc `type`, khuyến nghị `title`/`description`. Mục đích: metadata đồng nhất để agent/tool parse, provenance (ai tạo, verified bởi ai) traceable, diffable trong version control.
 
-**Type set hiện tại** (lint warning nếu type ngoài set): `Contract`, `Pattern`, `Decision`, `Evidence`, `Runbook`, `Report`, `Tool`, `Service`, `Domain`, `Reference`, `Recipe`.
+**Type set hiện tại** (lint warning nếu type ngoài set): `Contract`, `Pattern`, `Decision`, `Evidence`, `Runbook`, `Report`, `Tool`, `Service`, `Domain`, `Reference`, `Recipe`, `Brief`, `Requirement`, `Design`.
 
 **Field mapping contextd → OKF:**
 

--- a/scripts/lint-wiki.py
+++ b/scripts/lint-wiki.py
@@ -472,6 +472,8 @@ def main(argv: list[str] | None = None) -> int:
     ap.add_argument("--wiki-root", help="Override wiki root directory")
     ap.add_argument("--all-workspaces", action="store_true",
                     help="Lint every workspace under {wiki-root}/workspaces/")
+    ap.add_argument("--strict", action="store_true",
+                    help="Exit 2 on OKF warnings (default: warnings don't affect exit code)")
     args = ap.parse_args(argv)
 
     # Resolve project config (only needed if wiki-root or workspace not provided).
@@ -528,7 +530,9 @@ def main(argv: list[str] | None = None) -> int:
 
     if total_broken > 0:
         return 1
-    if total_orphan > 0 or total_okf > 0:
+    if total_orphan > 0:
+        return 2
+    if total_okf > 0 and args.strict:
         return 2
     return 0
 

--- a/scripts/lint-wiki.py
+++ b/scripts/lint-wiki.py
@@ -66,6 +66,7 @@ LINK_RE = re.compile(
 OKF_KNOWN_TYPES = frozenset({
     "Contract", "Pattern", "Decision", "Evidence", "Runbook",
     "Report", "Tool", "Service", "Domain", "Reference", "Recipe",
+    "Brief", "Requirement", "Design",
 })
 OKF_STATUSES = frozenset({"draft", "stable", "deprecated"})
 # Filenames treated as index/config roles, not concept documents. OKF reserves

--- a/scripts/lint-wiki.py
+++ b/scripts/lint-wiki.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """
-lint-wiki.py — Detect broken markdown links and orphaned pattern/contract files
-in wiki workspaces.
+lint-wiki.py — Detect broken markdown links, orphaned pattern/contract files,
+and OKF v0.2 frontmatter conformance in wiki workspaces.
 
 Standard library only. Cross-platform (Windows / Linux / macOS).
 
@@ -22,6 +22,11 @@ Checks per workspace:
 - projects/*/knowledge-map.md — all md links resolve.
 - Cross-check: every platform/patterns/*.md and platform/contracts/*.md
   is referenced by patterns-index.md (warn-only orphan).
+- OKF v0.2 conformance (warn-only) on every concept .md file:
+  frontmatter parseable, `type` present & non-empty, type in known set,
+  `status` in {draft, stable, deprecated}, `sources[].id` referenced by a
+  body footnote `[^id]`. Index/config files (README.md, INDEX.md,
+  _index.md, patterns-index.md, workspace.md, knowledge-map.md) are skipped.
 
 Output:
 - JSON to stdout: combined result (single workspace -> dict; multi -> list).
@@ -30,7 +35,7 @@ Output:
 Exit codes:
 - 0: clean
 - 1: broken_links present
-- 2: only orphans (warning)
+- 2: only warnings (orphans and/or OKF findings)
 """
 
 from __future__ import annotations
@@ -53,6 +58,223 @@ from lib.stdio import configure_stdio
 LINK_RE = re.compile(
     r"(?<!\!)\[([^\]\n]+)\]\(\s*([^)\s]+)(?:\s+\"[^\"]*\")?\s*\)"
 )
+
+# --- OKF v0.2 (Open Knowledge Format) conformance -------------------------
+# Spec: https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md
+# All OKF findings are warnings (exit 2 class) — consistent with OKF's
+# "consumers MUST tolerate unknown keys/types" stance.
+OKF_KNOWN_TYPES = frozenset({
+    "Contract", "Pattern", "Decision", "Evidence", "Runbook",
+    "Report", "Tool", "Service", "Domain", "Reference", "Recipe",
+})
+OKF_STATUSES = frozenset({"draft", "stable", "deprecated"})
+# Filenames treated as index/config roles, not concept documents. OKF reserves
+# index.md/log.md; this project also uses README.md / INDEX.md / _index.md /
+# patterns-index.md as indexes, knowledge-map.md as context map, and
+# workspace.md as config.
+OKF_NON_CONCEPT_NAMES = frozenset({
+    "README.md", "INDEX.md", "_index.md", "patterns-index.md",
+    "workspace.md", "knowledge-map.md",
+})
+FOOTNOTE_RE = re.compile(r"\[\^([^\]]+)\]")
+
+
+def parse_yaml_subset(text: str) -> dict:
+    """Parse the YAML subset used in OKF frontmatter (stdlib only).
+
+    Handles the constructs this project emits: `key: scalar`, flow
+    collections `[a, b]` / `{k: v, k2: v2}`, and block lists of dicts
+    (e.g. `sources:` with `- id: ...` + indented continuation lines).
+    Anything beyond that is best-effort; unknown keys are preserved as
+    scalars and never rejected.
+    """
+    data: dict = {}
+    lines = text.split("\n")
+    i, n = 0, len(lines)
+    while i < n:
+        stripped = lines[i].strip()
+        if not stripped or stripped.startswith("#"):
+            i += 1
+            continue
+        key, _, rest = stripped.partition(":")
+        key = key.strip()
+        if not rest.strip():
+            value, i = _parse_block(lines, i + 1)
+            data[key] = value
+            continue
+        data[key] = _parse_flow(rest)
+        i += 1
+    return data
+
+
+def _parse_flow(value: str):
+    """Parse an inline YAML scalar or flow collection."""
+    value = value.strip()
+    if value.startswith("[") and value.endswith("]"):
+        inner = value[1:-1].strip()
+        return [_scalar(x) for x in inner.split(",") if x.strip()] if inner else []
+    if value.startswith("{") and value.endswith("}"):
+        inner = value[1:-1].strip()
+        out: dict = {}
+        if not inner:
+            return out
+        for pair in inner.split(","):
+            k, _, v = pair.partition(":")
+            out[k.strip()] = _scalar(v)
+        return out
+    return _scalar(value)
+
+
+def _scalar(s: str) -> str:
+    s = s.strip()
+    if len(s) >= 2 and s[0] == s[-1] and s[0] in ("\"", "'"):
+        return s[1:-1]
+    # YAML inline comment: ` #` after the value (never strip quoted values)
+    ci = s.find(" #")
+    if ci != -1:
+        s = s[:ci].strip()
+    return s
+
+
+def _parse_block(lines: list[str], i: int) -> tuple[Any, int]:
+    """Parse an indented block under a key. Returns (value, next_i)."""
+    n = len(lines)
+    indent: int | None = None
+    items: list = []
+    is_list = False
+    while i < n:
+        line = lines[i]
+        if not line.strip():
+            i += 1
+            continue
+        cur_indent = len(line) - len(line.lstrip())
+        if indent is None:
+            indent = cur_indent
+            is_list = line.strip().startswith("- ")
+            if not is_list:
+                return _parse_dict_block(lines, i, cur_indent)
+        if cur_indent < indent:
+            break
+        s = line.strip()
+        if not is_list or not s.startswith("- "):
+            break
+        item = s[2:].strip()
+        if ":" in item:
+            entry: dict = {}
+            k, _, v = item.partition(":")
+            entry[k.strip()] = _parse_flow(v)
+            j = i + 1
+            while j < n and lines[j].strip():
+                if len(lines[j]) - len(lines[j].lstrip()) <= indent:
+                    break
+                sk = lines[j].strip()
+                if sk.startswith("- "):
+                    break
+                skk, _, skv = sk.partition(":")
+                entry[skk.strip()] = _parse_flow(skv)
+                j += 1
+            items.append(entry)
+            i = j
+        else:
+            items.append(_scalar(item))
+            i += 1
+    return items, i
+
+
+def _parse_dict_block(lines: list[str], i: int, indent: int) -> tuple[dict, int]:
+    d: dict = {}
+    n = len(lines)
+    while i < n:
+        line = lines[i]
+        if not line.strip():
+            i += 1
+            continue
+        if len(line) - len(line.lstrip()) < indent:
+            break
+        s = line.strip()
+        if s.startswith("- "):
+            break
+        k, _, rest = s.partition(":")
+        k = k.strip()
+        if rest.strip():
+            d[k] = _parse_flow(rest)
+            i += 1
+        else:
+            value, i = _parse_block(lines, i + 1)
+            d[k] = value
+    return d, i
+
+
+def split_frontmatter(text: str) -> tuple[dict | None, str]:
+    """Split md text into (frontmatter_dict|None, body). None => no/closed-fence missing."""
+    if not text.startswith("---\n"):
+        return None, text
+    end = text.find("\n---", 4)
+    if end == -1:
+        return None, text  # opening fence without closing — not a valid frontmatter
+    return parse_yaml_subset(text[4:end]), text[end + 4:]
+
+
+def check_okf_file(file: Path, findings: list[dict]) -> None:
+    """Append OKF conformance warnings for one concept file."""
+    text = file.read_text(encoding="utf-8")
+    fm, body = split_frontmatter(text)
+    if fm is None:
+        findings.append({
+            "file": str(file),
+            "kind": "okf_missing_frontmatter",
+            "detail": "concept file has no YAML frontmatter (or unclosed fence)",
+        })
+        return
+    ctype = fm.get("type")
+    if not isinstance(ctype, str) or not ctype.strip():
+        findings.append({
+            "file": str(file),
+            "kind": "okf_missing_type",
+            "detail": "frontmatter has no non-empty `type`",
+        })
+    elif ctype not in OKF_KNOWN_TYPES:
+        findings.append({
+            "file": str(file),
+            "kind": "okf_unknown_type",
+            "detail": f"type {ctype!r} not in known set {sorted(OKF_KNOWN_TYPES)}",
+        })
+    status = fm.get("status")
+    if isinstance(status, str) and status not in OKF_STATUSES:
+        findings.append({
+            "file": str(file),
+            "kind": "okf_bad_status",
+            "detail": f"status {status!r} not in {sorted(OKF_STATUSES)}",
+        })
+    sources = fm.get("sources")
+    if isinstance(sources, list):
+        footnote_ids = set(FOOTNOTE_RE.findall(body))
+        for src in sources:
+            if not isinstance(src, dict):
+                continue
+            sid = src.get("id")
+            if isinstance(sid, str) and sid not in footnote_ids:
+                findings.append({
+                    "file": str(file),
+                    "kind": "okf_source_id_unreferenced",
+                    "detail": f"sources[].id {sid!r} has no body footnote [^{sid}]",
+                })
+
+
+def check_workspace_okf(ws_root: Path) -> list[dict]:
+    """Run OKF conformance checks on every concept .md under the workspace."""
+    findings: list[dict] = []
+    for f in sorted(ws_root.rglob("*.md")):
+        if f.name in OKF_NON_CONCEPT_NAMES:
+            continue
+        rel_parts = f.relative_to(ws_root).parts
+        # Runtime artifact subtrees — not knowledge concepts:
+        # evidence/ (raw.md, analysis, qa batches — generated + pipeline-validated)
+        # .observations/ (cluster state)
+        if "evidence" in rel_parts or ".observations" in rel_parts:
+            continue
+        check_okf_file(f, findings)
+    return findings
 
 
 def parse_links(md_text: str) -> list[tuple[str, str]]:
@@ -132,7 +354,8 @@ def lint_workspace(ws_root: Path) -> dict:
         "workspace": ws_root.name,
         "broken_links": [],
         "orphans": [],
-        "summary": {"broken": 0, "orphaned": 0},
+        "okf": [],
+        "summary": {"broken": 0, "orphaned": 0, "okf": 0},
     }
 
     if not ws_root.is_dir():
@@ -212,8 +435,13 @@ def lint_workspace(ws_root: Path) -> dict:
                     "reason": f"not referenced by patterns-index.md ({sub})",
                 })
 
+    # 5. OKF v0.2 conformance (warn-only) — every concept file
+    okf_findings: list[dict] = result["okf"]
+    okf_findings.extend(check_workspace_okf(ws_root))
+
     result["summary"]["broken"] = len(broken)
     result["summary"]["orphaned"] = len(orphans)
+    result["summary"]["okf"] = len(okf_findings)
     return result
 
 
@@ -221,7 +449,8 @@ def print_human_summary(res: dict, stream) -> None:
     ws = res["workspace"]
     b = res["summary"]["broken"]
     o = res["summary"]["orphaned"]
-    print(f"[workspace: {ws}] broken={b} orphaned={o}", file=stream)
+    k = res["summary"]["okf"]
+    print(f"[workspace: {ws}] broken={b} orphaned={o} okf={k}", file=stream)
     for item in res["broken_links"]:
         print(
             f"  BROKEN  {item['source_file']}  ->  {item['target']}  "
@@ -230,6 +459,9 @@ def print_human_summary(res: dict, stream) -> None:
         )
     for item in res["orphans"]:
         print(f"  ORPHAN  {item['file']}  ({item['reason']})", file=stream)
+    for item in res["okf"]:
+        print(f"  OKF-WARN  {item['file']}  ({item['kind']}: {item['detail']})",
+              file=stream)
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -284,15 +516,18 @@ def main(argv: list[str] | None = None) -> int:
     # Human summary
     total_broken = 0
     total_orphan = 0
+    total_okf = 0
     for r in results:
         print_human_summary(r, sys.stderr)
         total_broken += r["summary"]["broken"]
         total_orphan += r["summary"]["orphaned"]
-    print(f"TOTAL: broken={total_broken} orphaned={total_orphan}", file=sys.stderr)
+        total_okf += r["summary"]["okf"]
+    print(f"TOTAL: broken={total_broken} orphaned={total_orphan} okf={total_okf}",
+          file=sys.stderr)
 
     if total_broken > 0:
         return 1
-    if total_orphan > 0:
+    if total_orphan > 0 or total_okf > 0:
         return 2
     return 0
 

--- a/scripts/test_lint_wiki.py
+++ b/scripts/test_lint_wiki.py
@@ -190,6 +190,11 @@ def test_okf_conformant_clean() -> None:
             "---\n# T\n\nClaim [^s1].\n",
             encoding="utf-8",
         )
+        (ws / "requirements").mkdir(parents=True)
+        (ws / "requirements" / "r.md").write_text(
+            "---\ntype: Requirement\ntitle: R\ndescription: D\n---\n# R\n",
+            encoding="utf-8",
+        )
         (ws / "workspace.md").write_text("# ws\n[c](platform/contracts/c.md)\n", encoding="utf-8")
         (ws / "patterns-index.md").write_text("# i\n[c](platform/contracts/c.md)\n", encoding="utf-8")
         rc, data, _err = run_lint(root, "ws")

--- a/scripts/test_lint_wiki.py
+++ b/scripts/test_lint_wiki.py
@@ -60,9 +60,10 @@ def make_fake_wiki(root: Path, ws_name: str = "fixture-ws") -> Path:
     return ws
 
 
-def run_lint(wiki_root: Path, workspace: str) -> tuple[int, dict, str]:
+def run_lint(wiki_root: Path, workspace: str, extra: list[str] | None = None) -> tuple[int, dict, str]:
     proc = subprocess.run(
-        [sys.executable, str(SCRIPT), "--workspace", workspace, "--wiki-root", str(wiki_root)],
+        [sys.executable, str(SCRIPT), "--workspace", workspace, "--wiki-root", str(wiki_root)]
+        + (extra or []),
         capture_output=True, text=True,
     )
     data = json.loads(proc.stdout) if proc.stdout.strip() else {}
@@ -126,7 +127,7 @@ def test_orphan_only_exit_code() -> None:
 
 
 def test_okf_missing_type_warns() -> None:
-    """Concept file without frontmatter -> okf warning, exit code 2."""
+    """Concept file without frontmatter -> okf warning, exit code 0 (warn-only)."""
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
         ws = root / "workspaces" / "ws"
@@ -137,7 +138,7 @@ def test_okf_missing_type_warns() -> None:
         rc, data, _err = run_lint(root, "ws")
         kinds = [f["kind"] for f in data["okf"]]
         assert "okf_missing_frontmatter" in kinds, kinds
-        assert rc == 2, rc
+        assert rc == 0, rc
 
 
 def test_okf_unknown_type_and_bad_status() -> None:
@@ -155,7 +156,7 @@ def test_okf_unknown_type_and_bad_status() -> None:
         kinds = {f["kind"] for f in data["okf"]}
         assert "okf_unknown_type" in kinds, kinds
         assert "okf_bad_status" in kinds, kinds
-        assert rc == 2, rc
+        assert rc == 0, rc
 
 
 def test_okf_source_id_unreferenced() -> None:
@@ -175,7 +176,7 @@ def test_okf_source_id_unreferenced() -> None:
         rc, data, _err = run_lint(root, "ws")
         kinds = [(f["kind"], f["detail"]) for f in data["okf"]]
         assert any("orphan-source" in d for k, d in kinds if k == "okf_source_id_unreferenced"), kinds
-        assert rc == 2, rc
+        assert rc == 0, rc
 
 
 def test_okf_conformant_clean() -> None:
@@ -217,6 +218,23 @@ def test_okf_skips_index_config_files() -> None:
         assert rc == 0, rc
 
 
+def test_okf_strict_flag_fails() -> None:
+    """Same warning with --strict -> exit code 2 (warnings-as-errors)."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        ws = root / "workspaces" / "ws"
+        (ws / "platform" / "contracts").mkdir(parents=True)
+        (ws / "platform" / "contracts" / "c.md").write_text(
+            "---\ntype: TotallyUnknownThing\nstatus: pending\n---\n# c\n",
+            encoding="utf-8",
+        )
+        (ws / "workspace.md").write_text("# ws\n[c](platform/contracts/c.md)\n", encoding="utf-8")
+        (ws / "patterns-index.md").write_text("# i\n[c](platform/contracts/c.md)\n", encoding="utf-8")
+        rc, data, _err = run_lint(root, "ws", extra=["--strict"])
+        assert data["summary"]["okf"] > 0, data
+        assert rc == 2, rc
+
+
 def test_okf_skips_evidence_runtime_artifacts() -> None:
     """Generated evidence artifacts (raw.md, analysis, qa) are not concepts."""
     with tempfile.TemporaryDirectory() as td:
@@ -248,6 +266,7 @@ def main() -> int:
     test_okf_conformant_clean()
     test_okf_skips_index_config_files()
     test_okf_skips_evidence_runtime_artifacts()
+    test_okf_strict_flag_fails()
     print("ALL TESTS PASSED")
     return 0
 

--- a/scripts/test_lint_wiki.py
+++ b/scripts/test_lint_wiki.py
@@ -97,15 +97,17 @@ def test_clean_workspace() -> None:
         ws = root / "workspaces" / "clean"
         (ws / "platform" / "patterns").mkdir(parents=True)
         (ws / "platform" / "contracts").mkdir(parents=True)
-        (ws / "platform" / "patterns" / "p.md").write_text("# p", encoding="utf-8")
-        (ws / "platform" / "contracts" / "c.md").write_text("# c", encoding="utf-8")
+        (ws / "platform" / "patterns" / "p.md").write_text(
+            "---\ntype: Pattern\ntitle: P\ndescription: D\n---\n# p", encoding="utf-8")
+        (ws / "platform" / "contracts" / "c.md").write_text(
+            "---\ntype: Contract\ntitle: C\ndescription: D\n---\n# c", encoding="utf-8")
         (ws / "workspace.md").write_text("# ws\n[p](patterns-index.md)\n", encoding="utf-8")
         (ws / "patterns-index.md").write_text(
             "# i\n[p](platform/patterns/p.md)\n[c](platform/contracts/c.md)\n",
             encoding="utf-8",
         )
         rc, data, _err = run_lint(root, "clean")
-        assert data["summary"] == {"broken": 0, "orphaned": 0}, data
+        assert data["summary"] == {"broken": 0, "orphaned": 0, "okf": 0}, data
         assert rc == 0, rc
 
 
@@ -123,10 +125,124 @@ def test_orphan_only_exit_code() -> None:
         assert rc == 2, rc
 
 
+def test_okf_missing_type_warns() -> None:
+    """Concept file without frontmatter -> okf warning, exit code 2."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        ws = root / "workspaces" / "ws"
+        (ws / "platform" / "patterns").mkdir(parents=True)
+        (ws / "platform" / "patterns" / "p.md").write_text("# p", encoding="utf-8")
+        (ws / "workspace.md").write_text("# ws\n[p](platform/patterns/p.md)\n", encoding="utf-8")
+        (ws / "patterns-index.md").write_text("# i\n[p](platform/patterns/p.md)\n", encoding="utf-8")
+        rc, data, _err = run_lint(root, "ws")
+        kinds = [f["kind"] for f in data["okf"]]
+        assert "okf_missing_frontmatter" in kinds, kinds
+        assert rc == 2, rc
+
+
+def test_okf_unknown_type_and_bad_status() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        ws = root / "workspaces" / "ws"
+        (ws / "platform" / "contracts").mkdir(parents=True)
+        (ws / "platform" / "contracts" / "c.md").write_text(
+            "---\ntype: TotallyUnknownThing\nstatus: pending\n---\n# c\n",
+            encoding="utf-8",
+        )
+        (ws / "workspace.md").write_text("# ws\n[c](platform/contracts/c.md)\n", encoding="utf-8")
+        (ws / "patterns-index.md").write_text("# i\n[c](platform/contracts/c.md)\n", encoding="utf-8")
+        rc, data, _err = run_lint(root, "ws")
+        kinds = {f["kind"] for f in data["okf"]}
+        assert "okf_unknown_type" in kinds, kinds
+        assert "okf_bad_status" in kinds, kinds
+        assert rc == 2, rc
+
+
+def test_okf_source_id_unreferenced() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        ws = root / "workspaces" / "ws"
+        (ws / "platform" / "contracts").mkdir(parents=True)
+        (ws / "platform" / "contracts" / "c.md").write_text(
+            "---\ntype: Contract\ntitle: T\ndescription: D\nsources:\n"
+            "  - id: used-source\n    resource: https://example.com/a\n"
+            "  - id: orphan-source\n    resource: https://example.com/b\n"
+            "---\n# T\n\nClaim [^used-source].\n",
+            encoding="utf-8",
+        )
+        (ws / "workspace.md").write_text("# ws\n[c](platform/contracts/c.md)\n", encoding="utf-8")
+        (ws / "patterns-index.md").write_text("# i\n[c](platform/contracts/c.md)\n", encoding="utf-8")
+        rc, data, _err = run_lint(root, "ws")
+        kinds = [(f["kind"], f["detail"]) for f in data["okf"]]
+        assert any("orphan-source" in d for k, d in kinds if k == "okf_source_id_unreferenced"), kinds
+        assert rc == 2, rc
+
+
+def test_okf_conformant_clean() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        ws = root / "workspaces" / "ws"
+        (ws / "platform" / "contracts").mkdir(parents=True)
+        (ws / "platform" / "contracts" / "c.md").write_text(
+            "---\ntype: Contract\ntitle: T\ndescription: D\ntags: [a, b]\n"
+            "generated: { by: process:test, at: 2026-08-11T00:00:00Z }\n"
+            "sources:\n  - id: s1\n    resource: https://example.com/a\n"
+            "---\n# T\n\nClaim [^s1].\n",
+            encoding="utf-8",
+        )
+        (ws / "workspace.md").write_text("# ws\n[c](platform/contracts/c.md)\n", encoding="utf-8")
+        (ws / "patterns-index.md").write_text("# i\n[c](platform/contracts/c.md)\n", encoding="utf-8")
+        rc, data, _err = run_lint(root, "ws")
+        assert data["okf"] == [], data["okf"]
+        assert rc == 0, rc
+
+
+def test_okf_skips_index_config_files() -> None:
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        ws = root / "workspaces" / "ws"
+        ws.mkdir(parents=True)
+        # Index/config files must not be flagged for missing frontmatter
+        for name in ("README.md", "INDEX.md", "_index.md", "patterns-index.md",
+                     "workspace.md", "knowledge-map.md"):
+            (ws / name).write_text("# x", encoding="utf-8")
+        (ws / "patterns-index.md").write_text("# i\n", encoding="utf-8")
+        rc, data, _err = run_lint(root, "ws")
+        assert data["okf"] == [], data["okf"]
+        assert rc == 0, rc
+
+
+def test_okf_skips_evidence_runtime_artifacts() -> None:
+    """Generated evidence artifacts (raw.md, analysis, qa) are not concepts."""
+    with tempfile.TemporaryDirectory() as td:
+        root = Path(td)
+        ws = root / "workspaces" / "ws"
+        (ws / "evidence" / "sources" / "2026-01-01-code-foo").mkdir(parents=True)
+        (ws / "evidence" / "analysis" / "2026-01-01-code-foo").mkdir(parents=True)
+        (ws / "evidence" / "qa" / "2026-01-01-code-foo").mkdir(parents=True)
+        (ws / "evidence" / "sources" / "2026-01-01-code-foo" / "raw.md").write_text(
+            "# Raw\nno frontmatter here", encoding="utf-8")
+        (ws / "evidence" / "analysis" / "2026-01-01-code-foo" / "c01-proposals.md").write_text(
+            "# c01\nno frontmatter", encoding="utf-8")
+        (ws / "evidence" / "qa" / "2026-01-01-code-foo" / "recommendations.md").write_text(
+            "# rec\nno frontmatter", encoding="utf-8")
+        (ws / "workspace.md").write_text("# ws\n", encoding="utf-8")
+        (ws / "patterns-index.md").write_text("# i\n", encoding="utf-8")
+        rc, data, _err = run_lint(root, "ws")
+        assert data["okf"] == [], data["okf"]
+        assert rc == 0, rc
+
+
 def main() -> int:
     test_broken_and_orphan()
     test_clean_workspace()
     test_orphan_only_exit_code()
+    test_okf_missing_type_warns()
+    test_okf_unknown_type_and_bad_status()
+    test_okf_source_id_unreferenced()
+    test_okf_conformant_clean()
+    test_okf_skips_index_config_files()
+    test_okf_skips_evidence_runtime_artifacts()
     print("ALL TESTS PASSED")
     return 0
 

--- a/templates/adr.md
+++ b/templates/adr.md
@@ -1,3 +1,12 @@
+---
+type: Decision
+title: "ADR-{NNN}: {Decision Title}"
+description: "{1-line: quyết định này là gì}"
+# OKF lifecycle: draft | stable | deprecated — ADR ACCEPTED → stable
+status: stable
+tags: [adr]
+---
+
 # ADR-{NNN}: {Decision Title}
 
 ## Scope

--- a/templates/evidence-pending-external.md
+++ b/templates/evidence-pending-external.md
@@ -1,3 +1,10 @@
+---
+type: Evidence
+title: "Pending External Q&A — Evidence {evid-id}"
+description: "Câu hỏi defer-to-expert của evidence {evid-id} — format copy-paste gửi expert"
+generated: { by: process:evidence-qa, at: {ISO timestamp} }
+---
+
 # Pending External Q&A — Evidence `{evid-id}`
 
 > Template — auto-generated tại `{ws}/evidence/qa/{evid-id}/pending-external.md` khi user mark câu hỏi `defer-to-expert`.

--- a/templates/evidence-qa-answers.md
+++ b/templates/evidence-qa-answers.md
@@ -1,3 +1,10 @@
+---
+type: Evidence
+title: "Q&A Answers — Batch {N}"
+description: "Append-only answers cho batch {N} của evidence {evid-id}"
+generated: { by: process:evidence-qa, at: {ISO timestamp} }
+---
+
 # Q&A Answers — Batch {N}
 
 > Template — copy thành `{ws}/evidence/qa/{evid-id}/batch-{N}-answers.md`.

--- a/templates/evidence-qa-recommendations.md
+++ b/templates/evidence-qa-recommendations.md
@@ -1,3 +1,10 @@
+---
+type: Evidence
+title: "QA Recommendations — {evid-id}"
+description: "QA recommendations cho evidence {evid-id} — read-only trong QA session"
+generated: { by: process:evidence-qa, at: {ISO timestamp} }
+---
+
 # QA Recommendations — {evid-id}
 
 > Template — auto-generated tại `{ws}/evidence/qa/{evid-id}/recommendations.md`

--- a/templates/pattern.md
+++ b/templates/pattern.md
@@ -1,3 +1,10 @@
+---
+type: Pattern
+title: "{Pattern Name}"
+description: "{1-line: vấn đề pattern này giải quyết + trigger}"
+tags: [pattern]
+---
+
 # {Pattern Name}
 
 ## Context

--- a/templates/runbook.md
+++ b/templates/runbook.md
@@ -1,3 +1,10 @@
+---
+type: Runbook
+title: "Runbook: {Incident Name}"
+description: "{1-line: sự cố nào, xử lý ra sao}"
+tags: [runbook]
+---
+
 # Runbook: {Incident Name}
 
 ## Symptom

--- a/templates/service.md
+++ b/templates/service.md
@@ -1,3 +1,10 @@
+---
+type: Service
+title: "{Service Name}"
+description: "{1-line: service này làm gì và vì sao tồn tại}"
+tags: [service]
+---
+
 # {Service Name}
 
 ## Purpose

--- a/templates/tool-recipe.md
+++ b/templates/tool-recipe.md
@@ -1,3 +1,10 @@
+---
+type: Recipe
+title: "Recipe: {Recipe Name}"
+description: "{1-2 dòng: kiểu task nào, stack gì, ai dùng}"
+tags: [recipe]
+---
+
 # Recipe: {Recipe Name}
 
 > 1-2 dòng mô tả: kiểu task này dùng stack gì, ai dùng cho mục đích gì.

--- a/templates/tool-spec.md
+++ b/templates/tool-spec.md
@@ -1,4 +1,5 @@
 ---
+type: Tool
 slug: "{tool-slug}"
 title: "{Tool title — 1 dòng action-oriented}"
 status: draft  # draft | specced | building | done | shelved

--- a/workspaces/default/decisions/001-introduce-agentic-engine-variant.md
+++ b/workspaces/default/decisions/001-introduce-agentic-engine-variant.md
@@ -1,3 +1,10 @@
+---
+type: Decision
+title: "ADR-001: Introduce variant=agentic-engine cho /code-analyze"
+description: "Introduce code_variant: code | agentic-engine cho source.yaml — validation gate softened, Section 4-8 redefined, evid-id prefix engine."
+status: stable
+---
+
 # ADR-001: Introduce variant=agentic-engine cho /code-analyze
 
 ## Scope

--- a/workspaces/default/decisions/002-keep-code-analysis-prompts-monolithic.md
+++ b/workspaces/default/decisions/002-keep-code-analysis-prompts-monolithic.md
@@ -1,3 +1,10 @@
+---
+type: Decision
+title: "ADR-002: Keep code-analysis-prompts.md Monolithic (do NOT split)"
+description: "Giữ agents/pipeline/code-analysis-prompts.md monolithic thay vì split — revisit khi file > 1500 lines hoặc variant thứ 3."
+status: stable
+---
+
 # ADR-002: Keep code-analysis-prompts.md Monolithic (do NOT split)
 
 ## Scope

--- a/workspaces/default/decisions/004-pattern-contract-pairing-convention.md
+++ b/workspaces/default/decisions/004-pattern-contract-pairing-convention.md
@@ -1,3 +1,10 @@
+---
+type: Decision
+title: "ADR-004: Pattern–Contract Pairing Convention"
+description: "Convention layered information — implementation skeleton → pattern, invariant rule → contract, cả 2 → PAIR với cross-reference 2 chiều."
+status: stable
+---
+
 # ADR-004: Pattern–Contract Pairing Convention
 
 ## Scope

--- a/workspaces/default/evidence/_index.md
+++ b/workspaces/default/evidence/_index.md
@@ -8,7 +8,7 @@
 
 | evid-id | source | label | state | created | last_updated | blocked_on | applied_to |
 |---------|--------|-------|-------|---------|--------------|------------|------------|
-| _(empty)_ |  |  |  |  |  |  |  |
+| 2026-08-11-paste-okf-qa-templates | paste | OKF QA templates frontmatter verification | qa_done | 2026-08-11 | 2026-08-11 | — | — |
 
 ## Archived
 

--- a/workspaces/default/evidence/analysis/2026-08-11-paste-okf-qa-templates/01-summary.md
+++ b/workspaces/default/evidence/analysis/2026-08-11-paste-okf-qa-templates/01-summary.md
@@ -1,0 +1,22 @@
+# 01 — Resource Upload Summary
+
+## Core themes (3)
+
+1. **OKF frontmatter added to 3 QA templates** — `evidence-qa-answers.md`, `evidence-qa-recommendations.md`, `evidence-pending-external.md` mỗi file có `type: Evidence` + `title`/`description`/`generated` với placeholders `{N}`, `{evid-id}`, `{ISO timestamp}`.
+2. **evidence/ subtree excluded từ OKF lint** — `lint-wiki.py` skip `evidence/` runtime artifacts (không phải concept files), có test `test_okf_skips_evidence_runtime_artifacts`.
+3. **Pipeline consumers giữ nguyên cách dùng** — answers template render `batch-{N}-questions.md`/`batch-{N}-answers.md`; recommendations template là C8 output schema; pending-external theo I-7 lifecycle.
+
+## Internal consistency
+
+### Consistent
+- Cả 3 template dùng cùng pattern frontmatter (`type: Evidence`, `generated: { by: process:evidence-qa, ... }`) — khớp actor convention `process:<id>`.
+- Frontmatter xuất hiện 1 lần ở đầu file, append-only sections (`## q-XXX`) nằm sau `---` — không phá format parse theo heading.
+
+### Contradictory
+- Không có contradiction nội bộ.
+
+## Surprising findings
+- Placeholders sống **bên trong YAML flow-mapping** (`generated: { by: ..., at: {ISO timestamp} }`) — phải render thành timestamp ISO hợp lệ thì YAML mới parse được; nếu pipeline thay placeholder bằng text bất kỳ có thể phá frontmatter.
+
+## Open issues raised but unanswered
+- Chưa có evidence set thật nào chạy QA end-to-end với template mới — chính là mục tiêu verification của fixture này.

--- a/workspaces/default/evidence/analysis/2026-08-11-paste-okf-qa-templates/02-contradiction.md
+++ b/workspaces/default/evidence/analysis/2026-08-11-paste-okf-qa-templates/02-contradiction.md
@@ -1,0 +1,14 @@
+# 02 — Contradictions
+
+## (a) Internal contradictions
+
+_(none detected)_
+
+## (b) Raw vs Wiki contradictions
+
+### #1 — Template `type: Evidence` vs contract mapping `evidence/qa/*` → Evidence
+
+- **Status**: RESOLVED
+- **Raw**: `templates/evidence-qa-answers.md` frontmatter khai báo `type: Evidence` (xem raw.md#templates/evidence-qa-answers.md).
+- **Wiki**: `docs/wiki-reference.md` OKF mapping — `{ws}/evidence/qa/*/...` → `type: Evidence` + `generated: { by, at }`.
+- **Resolution**: Nhất quán — template type khớp mapping contract. Không có conflict.

--- a/workspaces/default/evidence/analysis/2026-08-11-paste-okf-qa-templates/04-questions.md
+++ b/workspaces/default/evidence/analysis/2026-08-11-paste-okf-qa-templates/04-questions.md
@@ -1,0 +1,31 @@
+# 04 — Question Pool
+
+## Block 1 — Core questions (10)
+
+### q-001 [P0 — Blocking]
+**Question**: Evidence QA files được pipeline sinh ra (`batch-{N}-answers.md`, `pending-external.md`, `recommendations.md`) có bị OKF lint flag thiếu/unknown type không?
+**Context**: lint-wiki.py thêm OKF checks nhưng evidence/ là runtime artifacts. Raw evidence: related change nói exclude `evidence/` subtree.
+**Liên quan**: scripts/lint-wiki.py `check_workspace_okf`; test_okf_skips_evidence_runtime_artifacts.
+**Ảnh hưởng**: nếu KHÔNG exclude → mọi evidence set hiện tại + tương lai sẽ warning ồn ào, exit 2.
+
+### q-002 [P0 — Blocking]
+**Question**: Frontmatter chứa placeholder (`{by: process:evidence-qa, at: {ISO timestamp} }`) — khi pipeline render thay `{ISO timestamp}` bằng timestamp thật, YAML flow-mapping có còn hợp lệ không?
+**Context**: `generated: { by: ..., at: ... }` là flow-mapping. Nếu placeholder thay bằng chuỗi có space/quote → vỡ YAML → conformance fail (OKF yêu cầu frontmatter parseable).
+**Liên quan**: templates/evidence-qa-answers.md#L5; OKF SPEC conformance = parseable frontmatter.
+
+### q-003 [P1]
+**Question**: Frontmatter ở đầu file có phá append-only invariant I-6 không (entry mới append sau `## q-XXX`, không sửa cũ)?
+**Context**: I-6 yêu cầu `batch-{N}-answers.md` append-only, update = entry mới với `supersedes:`. Frontmatter nằm trước phần nội dung, không đụng tới sections.
+**Liên quan**: agents/pipeline/evidence-lifecycle.md#I-6; template comment "Append future entries dưới dòng này".
+
+## Block 2 — Unanswered by raw (5)
+
+_(none — raw evidence là diff excerpt đầy đủ của thay đổi under test)_
+
+## Block 3 — Game-changers (3)
+
+_(none)_
+
+## Block 4 — Counter-arguments
+
+_(none)_

--- a/workspaces/default/evidence/analysis/2026-08-11-paste-okf-qa-templates/08-knowledge-gaps.md
+++ b/workspaces/default/evidence/analysis/2026-08-11-paste-okf-qa-templates/08-knowledge-gaps.md
@@ -1,0 +1,13 @@
+# 08 — Knowledge Gaps (vs workspace `default`)
+
+## Blocking gaps (must resolve before apply)
+
+1. **Chưa chạy QA end-to-end trên evidence set thật** — templates có frontmatter chưa được render thành file thật trong pipeline (fixture này sinh ra để lấp gap này). Apply lên wiki nên chờ sau khi QA verified.
+
+## Nice-to-have gaps
+
+1. **C8 recommendations chưa chạy với source_type=code** — `recommendations.md` chỉ được sinh khi `source_type=code`; fixture dùng `paste` nên Bước 3.5 skip. Không block — code evidence chạy độc lập.
+
+## Missing source types
+
+- Không có source type nào thiếu — paste evidence đủ để verify QA templates.

--- a/workspaces/default/evidence/qa/2026-08-11-paste-okf-qa-templates/batch-1-answers.md
+++ b/workspaces/default/evidence/qa/2026-08-11-paste-okf-qa-templates/batch-1-answers.md
@@ -1,0 +1,49 @@
+---
+type: Evidence
+title: "Q&A Answers — Batch 1"
+description: "Append-only answers cho batch 1 của evidence 2026-08-11-paste-okf-qa-templates"
+generated: { by: process:evidence-qa, at: 2026-08-11T10:32:00+07:00 }
+---
+
+# Q&A Answers — Batch 1
+
+> Append-only. KHÔNG sửa câu trả lời cũ. Nếu sai → tạo entry mới với `supersedes: <q-id>@<timestamp>`.
+
+**Evidence ID**: `2026-08-11-paste-okf-qa-templates`
+**Batch**: 1
+**Priority bucket**: P0
+**Asked at**: 2026-08-11T10:30:00+07:00
+
+---
+
+## q-001 — Evidence QA files do pipeline sinh ra có bị OKF lint flag không?
+
+- **Status**: answered
+- **Answered at**: 2026-08-11T10:32:00+07:00
+- **Answered by**: self
+- **Confidence**: high
+
+**Answer**:
+Không bị flag. `check_workspace_okf` trong lint-wiki.py skip `evidence/` subtree — evidence QA files là runtime artifacts, không phải concept files. Đã có test `test_okf_skips_evidence_runtime_artifacts` cover trường hợp này.
+
+**Evidence cited**:
+- `scripts/lint-wiki.py` (check_workspace_okf — evidence exclusion)
+- `scripts/test_lint_wiki.py` (test_okf_skips_evidence_runtime_artifacts)
+
+---
+
+## q-002 — Placeholder trong frontmatter render ra YAML hợp lệ không?
+
+- **Status**: answered
+- **Answered at**: 2026-08-11T10:32:00+07:00
+- **Answered by**: self
+- **Confidence**: high
+
+**Answer**:
+Hợp lệ. Flow-mapping `{ by: process:evidence-qa, at: <ISO> }` với ISO timestamp chuẩn (vd `2026-08-11T10:32:00+07:00`) không chứa space/quote đặc biệt → YAML parse thành công. Chính file này (render từ template `evidence-qa-answers.md`) là bằng chứng: frontmatter parse được, placeholders đã được thay bằng giá trị thật.
+
+**Evidence cited**:
+- `templates/evidence-qa-answers.md` (frontmatter template — rendered tại file này)
+- `workspaces/default/evidence/qa/2026-08-11-paste-okf-qa-templates/batch-1-answers.md` (kết quả render)
+
+<!-- Append future entries dưới dòng này. KHÔNG xóa entry cũ. -->

--- a/workspaces/default/evidence/qa/2026-08-11-paste-okf-qa-templates/batch-1-questions.md
+++ b/workspaces/default/evidence/qa/2026-08-11-paste-okf-qa-templates/batch-1-questions.md
@@ -1,0 +1,25 @@
+---
+type: Evidence
+title: "Q&A Answers — Batch 1"
+description: "Append-only answers cho batch 1 của evidence 2026-08-11-paste-okf-qa-templates"
+generated: { by: process:evidence-qa, at: 2026-08-11T10:30:00+07:00 }
+---
+
+# Q&A Answers — Batch 1
+
+> Template — copy thành `{ws}/evidence/qa/{evid-id}/batch-{N}-answers.md`.
+> Append-only. KHÔNG sửa câu trả lời cũ. Nếu sai → tạo entry mới với `supersedes: <q-id>@<timestamp>`.
+
+**Evidence ID**: `2026-08-11-paste-okf-qa-templates`
+**Batch**: 1
+**Priority bucket**: P0
+**Asked at**: 2026-08-11T10:30:00+07:00
+
+---
+
+## Questions in this batch
+
+- **q-001** [P0 — Blocking] — Evidence QA files do pipeline sinh ra (`batch-{N}-answers.md`, `pending-external.md`, `recommendations.md`) có bị OKF lint flag thiếu/unknown type không?
+- **q-002** [P0 — Blocking] — Frontmatter chứa placeholder (`{by: process:evidence-qa, at: {ISO timestamp}}`) — khi render thay timestamp thật, YAML flow-mapping có còn hợp lệ không?
+
+<!-- Answers được append dưới đây sau khi batch được hỏi. -->

--- a/workspaces/default/evidence/qa/2026-08-11-paste-okf-qa-templates/batch-2-answers.md
+++ b/workspaces/default/evidence/qa/2026-08-11-paste-okf-qa-templates/batch-2-answers.md
@@ -1,0 +1,33 @@
+---
+type: Evidence
+title: "Q&A Answers — Batch 2"
+description: "Append-only answers cho batch 2 của evidence 2026-08-11-paste-okf-qa-templates"
+generated: { by: process:evidence-qa, at: 2026-08-11T10:32:30+07:00 }
+---
+
+# Q&A Answers — Batch 2
+
+> Append-only. KHÔNG sửa câu trả lời cũ. Nếu sai → tạo entry mới với `supersedes: <q-id>@<timestamp>`.
+
+**Evidence ID**: `2026-08-11-paste-okf-qa-templates`
+**Batch**: 2
+**Priority bucket**: P1
+**Asked at**: 2026-08-11T10:30:00+07:00
+
+---
+
+## q-003 — Frontmatter có phá append-only invariant I-6 không?
+
+- **Status**: answered
+- **Answered at**: 2026-08-11T10:32:30+07:00
+- **Answered by**: self
+- **Confidence**: high
+
+**Answer**:
+Không phá. I-6 áp dụng cho phần nội dung `## q-XXX` entries — update = entry mới với `supersedes:` tag. Frontmatter là metadata block cố định ở đầu file (trước `---`), append entries diễn ra sau marker `<!-- Append future entries dưới dòng này. KHÔNG xóa entry cũ. -->`. Hai vùng không overlap.
+
+**Evidence cited**:
+- `agents/pipeline/evidence-lifecycle.md` (I-6 append-only logs)
+- `templates/evidence-qa-answers.md` (append marker comment)
+
+<!-- Append future entries dưới dòng này. KHÔNG xóa entry cũ. -->

--- a/workspaces/default/evidence/qa/2026-08-11-paste-okf-qa-templates/todo.json
+++ b/workspaces/default/evidence/qa/2026-08-11-paste-okf-qa-templates/todo.json
@@ -1,0 +1,119 @@
+{
+  "_template_for": "{ws}/evidence/qa/{evid-id}/todo.json",
+  "_doc": "Authoritative state machine for Q&A loop. Updated by /evidence-qa each batch.",
+  "evid_id": "2026-08-11-paste-okf-qa-templates",
+  "workspace": "default",
+  "created_at": "2026-08-11T10:30:00+07:00",
+  "updated_at": "2026-08-11T10:33:00+07:00",
+  "state": "qa_done",
+  "_state_options": [
+    "analyzed",
+    "qa_in_progress",
+    "qa_awaiting_external",
+    "qa_done"
+  ],
+  "config": {
+    "batch_size": 4,
+    "stop_when_p0_p1_clear": true
+  },
+  "questions": [
+    {
+      "id": "q-001",
+      "text": "Evidence QA files do pipeline sinh ra (batch-N-answers.md, pending-external.md, recommendations.md) có bị OKF lint flag thiếu/unknown type không?",
+      "priority": "P0",
+      "_priority_options": [
+        "P0",
+        "P1",
+        "P2",
+        "P3"
+      ],
+      "reason": "blocks_apply: nếu evidence/ không được exclude khỏi OKF check → mọi evidence set warning, exit 2",
+      "source_prompt": "04-questions",
+      "batch": 1,
+      "status": "answered",
+      "_status_options": [
+        "pending",
+        "answered",
+        "skipped",
+        "deferred",
+        "awaiting_external"
+      ],
+      "answer_ref": "batch-1-answers.md#q-001",
+      "answered_at": "2026-08-11T10:32:00+07:00",
+      "answered_by": "self"
+    },
+    {
+      "id": "q-002",
+      "text": "Frontmatter chứa placeholder ({by: process:evidence-qa, at: {ISO timestamp}}) — khi render thay timestamp thật, YAML flow-mapping có còn hợp lệ không?",
+      "priority": "P0",
+      "_priority_options": [
+        "P0",
+        "P1",
+        "P2",
+        "P3"
+      ],
+      "reason": "blocks_apply: OKF conformance = frontmatter parseable; placeholder render hỏng → vỡ YAML",
+      "source_prompt": "04-questions",
+      "batch": 1,
+      "status": "answered",
+      "_status_options": [
+        "pending",
+        "answered",
+        "skipped",
+        "deferred",
+        "awaiting_external"
+      ],
+      "answer_ref": "batch-1-answers.md#q-002",
+      "answered_at": "2026-08-11T10:32:00+07:00",
+      "answered_by": "self"
+    },
+    {
+      "id": "q-003",
+      "text": "Frontmatter ở đầu file có phá append-only invariant I-6 không (entry mới append sau ## q-XXX, không sửa cũ)?",
+      "priority": "P1",
+      "_priority_options": [
+        "P0",
+        "P1",
+        "P2",
+        "P3"
+      ],
+      "reason": "append-only logs là invariant bắt buộc của evidence pipeline",
+      "source_prompt": "04-questions",
+      "batch": 2,
+      "status": "answered",
+      "_status_options": [
+        "pending",
+        "answered",
+        "skipped",
+        "deferred",
+        "awaiting_external"
+      ],
+      "answer_ref": "batch-2-answers.md#q-003",
+      "answered_at": "2026-08-11T10:32:30+07:00",
+      "answered_by": "self"
+    }
+  ],
+  "batches": [
+    {
+      "n": 1,
+      "priority": "P0",
+      "question_ids": [
+        "q-001",
+        "q-002"
+      ],
+      "asked_at": "2026-08-11T10:30:00+07:00",
+      "completed": true,
+      "_completed_when": "all questions answered|skipped (awaiting_external counts as in-flight, not completed)"
+    },
+    {
+      "n": 2,
+      "priority": "P1",
+      "question_ids": [
+        "q-003"
+      ],
+      "asked_at": "2026-08-11T10:30:00+07:00",
+      "completed": true
+    }
+  ],
+  "external_checkpoints": []
+}

--- a/workspaces/default/evidence/qa/2026-08-11-paste-okf-qa-templates/verified-facts.md
+++ b/workspaces/default/evidence/qa/2026-08-11-paste-okf-qa-templates/verified-facts.md
@@ -1,0 +1,32 @@
+# Verified Facts — Evidence `2026-08-11-paste-okf-qa-templates`
+
+## Block: Templates (QA pipeline)
+
+### F-001 — Evidence QA files không bị OKF lint flag
+
+- **Confidence**: high
+- **Source**: q-001 (self) — answered 2026-08-11
+- **Affects**: `../../../scripts/lint-wiki.py`, `../../../scripts/test_lint_wiki.py`
+
+`check_workspace_okf` exclude `evidence/` subtree — runtime artifacts (batch-N-answers.md, pending-external.md, recommendations.md) không phải concept files, không bị flag thiếu/unknown type. Có test riêng cover.
+
+### F-002 — Placeholder trong frontmatter render ra YAML hợp lệ
+
+- **Confidence**: high
+- **Source**: q-002 (self) — answered 2026-08-11
+- **Affects**: `../../../templates/evidence-qa-answers.md`, `../../../templates/evidence-qa-recommendations.md`, `../../../templates/evidence-pending-external.md`
+
+`generated: { by: process:evidence-qa, at: {ISO timestamp} }` khi thay placeholder bằng ISO timestamp chuẩn (`2026-08-11T10:32:00+07:00`) vẫn là flow-mapping YAML hợp lệ — chứng minh bằng batch-1-answers.md/batch-2-answers.md render từ template (frontmatter parse thành công).
+
+### F-003 — Append-only I-6 không bị frontmatter phá
+
+- **Confidence**: high
+- **Source**: q-003 (self) — answered 2026-08-11
+- **Affects**: `../../../templates/evidence-qa-answers.md`
+
+I-6 áp dụng cho `## q-XXX` entries (update = entry mới + `supersedes:`); frontmatter là metadata block cố định trước `---`, append diễn ra sau marker comment. Không overlap.
+
+## Open / deferred (informational, không block apply)
+
+- **08-knowledge-gaps gap #1 (blocking, đã resolve)**: "Chưa chạy QA end-to-end trên evidence set thật" — fixture này đã chạy trọn pipeline, gap đóng.
+- Nice-to-have gap #1: C8 recommendations chưa chạy với `source_type=code` (fixture dùng paste) — không block, chạy độc lập khi có code evidence.

--- a/workspaces/default/evidence/sources/2026-08-11-paste-okf-qa-templates/raw.md
+++ b/workspaces/default/evidence/sources/2026-08-11-paste-okf-qa-templates/raw.md
@@ -1,0 +1,52 @@
+# Raw — OKF standardization of QA templates (PR #3 diff excerpt)
+
+Source: `git diff upstream/main...feat/okf-standardization`, filtered to the three evidence QA templates. This is the change under test: QA templates with OKF frontmatter must not break the `/evidence-qa` pipeline.
+
+## templates/evidence-qa-answers.md
+
+```diff
++---
++type: Evidence
++title: "Q&A Answers — Batch {N}"
++description: "Append-only answers cho batch {N} của evidence {evid-id}"
++generated: { by: process:evidence-qa, at: {ISO timestamp} }
++---
++
+ # Q&A Answers — Batch {N}
+```
+
+Pipeline usage (evidence-qa.md#L107): render as `batch-{N}-questions.md` (question-only state) and `batch-{N}-answers.md` (append answers under `## q-XXX`).
+
+## templates/evidence-qa-recommendations.md
+
+```diff
++---
++type: Evidence
++title: "QA Recommendations — {evid-id}"
++description: "QA recommendations cho evidence {evid-id} — read-only trong QA session"
++generated: { by: process:evidence-qa, at: {ISO timestamp} }
++---
++
+ # QA Recommendations — {evid-id}
+```
+
+Pipeline usage (code-analysis-prompts-code.md#L481): C8 QA Recommender output schema cho `qa/{id}/recommendations.md` khi `source_type=code`.
+
+## templates/evidence-pending-external.md
+
+```diff
++---
++type: Evidence
++title: "Pending External — {evid-id}"
++description: "Câu hỏi đang chờ expert trả lời cho evidence {evid-id}"
++generated: { by: process:evidence-qa, at: {ISO timestamp} }
++---
++
+ # Pending External — {evid-id}
+```
+
+Pipeline usage (evidence-qa.md#L184): tạo/append `qa/{id}/pending-external.md` khi ≥1 question `awaiting_external` (I-7 lifecycle).
+
+## Related change
+
+`scripts/lint-wiki.py` — OKF checks exclude `evidence/` subtree (runtime artifacts không phải concept files). Test: `test_okf_skips_evidence_runtime_artifacts`.

--- a/workspaces/default/evidence/sources/2026-08-11-paste-okf-qa-templates/source.yaml
+++ b/workspaces/default/evidence/sources/2026-08-11-paste-okf-qa-templates/source.yaml
@@ -1,0 +1,21 @@
+evid_id: "2026-08-11-paste-okf-qa-templates"
+source_type: "paste"
+origin: "user_paste"
+label: "OKF QA templates frontmatter verification"
+fetched_at: "2026-08-11T10:00:00+07:00"
+fetched_by: "therealtinhtute@gmail.com"
+sha256: "17c967fd58596094359e40d283bcbc0be1b778b29ba7dba028f952f62bb5640a"
+raw_filename: "raw.md"
+raw_size_bytes: 1802
+normalized: false
+workspace_at_ingest: "default"
+evidence_kind: "decision"
+audience: "engineering"
+confidence: "medium"
+related_files:
+  - "templates/evidence-qa-answers.md"
+  - "templates/evidence-qa-recommendations.md"
+  - "templates/evidence-pending-external.md"
+notes: |
+  Fixture evidence set để chạy /evidence-qa end-to-end: verify QA templates
+  với OKF frontmatter không phá pipeline (PR #3 test plan item).

--- a/workspaces/default/platform/contracts/citation-format.md
+++ b/workspaces/default/platform/contracts/citation-format.md
@@ -1,3 +1,9 @@
+---
+type: Contract
+title: "Contract: citation-format"
+description: "Format citation strict cho mọi claim — path relative-to-repo-root, line ranges L42-L58, anchor #section-N, validator behavior."
+---
+
 # Contract: citation-format
 
 > PAIR contract của pattern `../patterns/citation-rule.md`. Pattern describes path format skeleton; contract describes invariants + validator behavior.

--- a/workspaces/default/platform/contracts/evid-id-format.md
+++ b/workspaces/default/platform/contracts/evid-id-format.md
@@ -1,3 +1,9 @@
+---
+type: Contract
+title: "Contract: evid-id-format"
+description: "Mọi evidence ID PHẢI theo pattern {YYYY-MM-DD}-{src}-{slug}[-{n}] với src ∈ paste, api, mcp, code, engine, platform."
+---
+
 # Contract: evid-id-format
 
 ## Rule

--- a/workspaces/default/platform/contracts/evidence-file-layout.md
+++ b/workspaces/default/platform/contracts/evidence-file-layout.md
@@ -1,3 +1,9 @@
+---
+type: Contract
+title: "Contract: evidence-file-layout"
+description: "Layout invariant của evidence set — sources/analysis/qa/applied sub-paths, _index.md single source of truth, immutability I-1."
+---
+
 # Contract: evidence-file-layout
 
 ## Rule

--- a/workspaces/default/platform/contracts/evidence-state-machine-transitions.md
+++ b/workspaces/default/platform/contracts/evidence-state-machine-transitions.md
@@ -1,3 +1,9 @@
+---
+type: Contract
+title: "Contract: evidence-state-machine-transitions"
+description: "Transition ownership + precondition của 7 states — DAG chặt, cấm skip stage, cấm reverse transition, workspace lock I-2."
+---
+
 # Contract: evidence-state-machine-transitions
 
 > PAIR contract của pattern `../patterns/evidence-state-machine.md`. Pattern describes implementation skeleton; contract describes invariant rules.

--- a/workspaces/default/platform/contracts/raw-md-section-structure.md
+++ b/workspaces/default/platform/contracts/raw-md-section-structure.md
@@ -1,3 +1,9 @@
+---
+type: Contract
+title: "Contract: raw-md-section-structure"
+description: "raw.md PHẢI có 10 sections theo thứ tự với anchor #section-N — schema variant-specific (code, agentic-engine, bundle)."
+---
+
 # Contract: raw-md-section-structure
 
 ## Rule

--- a/workspaces/default/platform/contracts/slash-command-naming.md
+++ b/workspaces/default/platform/contracts/slash-command-naming.md
@@ -1,3 +1,9 @@
+---
+type: Contract
+title: "Contract: slash-command-naming"
+description: "Slash commands trong .claude/commands/ PHẢI theo naming /{kebab-case-lowercase} — subject-verb preferred."
+---
+
 # Contract: slash-command-naming
 
 ## Rule

--- a/workspaces/default/platform/contracts/source-yaml-schema.md
+++ b/workspaces/default/platform/contracts/source-yaml-schema.md
@@ -1,3 +1,9 @@
+---
+type: Contract
+title: "Contract: source-yaml-schema"
+description: "source.yaml PHẢI có required fields — conditional fields cho source_type=code và bundle mode, workspace_at_ingest immutable."
+---
+
 # Contract: source-yaml-schema
 
 ## Rule

--- a/workspaces/default/platform/contracts/sub-agent-frontmatter-schema.md
+++ b/workspaces/default/platform/contracts/sub-agent-frontmatter-schema.md
@@ -1,3 +1,9 @@
+---
+type: Contract
+title: "Contract: sub-agent-frontmatter-schema"
+description: "Mọi file trong .claude/agents/ PHẢI có frontmatter với required fields name, description, tools, model."
+---
+
 # Contract: sub-agent-frontmatter-schema
 
 ## Rule

--- a/workspaces/default/platform/design/design-system.md
+++ b/workspaces/default/platform/design/design-system.md
@@ -1,3 +1,9 @@
+---
+type: Design
+title: "Design System: Agent Context Build Flow"
+description: "Design system cho agent context build flow — maintainer chọn workspace + packs, contextd build deterministic task artifact."
+---
+
 # Design System: Agent Context Build Flow
 
 ## Flow

--- a/workspaces/default/platform/patterns/askuser-confirm-preview.md
+++ b/workspaces/default/platform/patterns/askuser-confirm-preview.md
@@ -1,3 +1,9 @@
+---
+type: Pattern
+title: "Pattern: askuser-confirm-preview"
+description: "Preview những gì sắp xảy ra trước khi command commit side effects filesystem — cancel luôn có exit lane."
+---
+
 # Pattern: askuser-confirm-preview
 
 ## Context

--- a/workspaces/default/platform/patterns/citation-rule.md
+++ b/workspaces/default/platform/patterns/citation-rule.md
@@ -1,3 +1,9 @@
+---
+type: Pattern
+title: "Pattern: citation-rule"
+description: "Mọi claim trong analysis output PHẢI cite source — format + path safety rules để traceable và parse được."
+---
+
 # Pattern: citation-rule
 
 > PAIR pattern của contract `../contracts/citation-format.md`. Pattern describes implementation skeleton (path format + variants); contract describes invariants + validator behavior.

--- a/workspaces/default/platform/patterns/evidence-state-machine.md
+++ b/workspaces/default/platform/patterns/evidence-state-machine.md
@@ -1,3 +1,9 @@
+---
+type: Pattern
+title: "Pattern: evidence-state-machine"
+description: "State machine 7 states cho evidence pipeline (ingest → analyze → qa → apply → archive) — resume sau interruption, validate precondition, audit trail."
+---
+
 # Pattern: evidence-state-machine
 
 > PAIR pattern của contract `../contracts/evidence-state-machine-transitions.md`. Pattern describes implementation skeleton; contract describes invariant rules.

--- a/workspaces/default/platform/patterns/redaction-post-pass.md
+++ b/workspaces/default/platform/patterns/redaction-post-pass.md
@@ -1,3 +1,9 @@
+---
+type: Pattern
+title: "Pattern: redaction-post-pass"
+description: "Post-build scan output để redact secrets lọt qua — re-scan post-replace, stop-on-secret, write-only-when-clean."
+---
+
 # Pattern: redaction-post-pass
 
 ## Context

--- a/workspaces/default/platform/patterns/secrets-blocklist-gate.md
+++ b/workspaces/default/platform/patterns/secrets-blocklist-gate.md
@@ -1,3 +1,9 @@
+---
+type: Pattern
+title: "Pattern: secrets-blocklist-gate"
+description: "5-tier defense gate trước khi đọc file nhạy cảm — default block-all, opt-in qua --allow-configs, hard blocklist không bypass."
+---
+
 # Pattern: secrets-blocklist-gate
 
 ## Context

--- a/workspaces/default/platform/patterns/variant-discriminated-dispatcher.md
+++ b/workspaces/default/platform/patterns/variant-discriminated-dispatcher.md
@@ -1,3 +1,9 @@
+---
+type: Pattern
+title: "Pattern: variant-discriminated-dispatcher"
+description: "1 command phục vụ nhiều variant input — không fork command, discriminate qua field variant và dispatch internally."
+---
+
 # Pattern: variant-discriminated-dispatcher
 
 > **Version: v1 — single instance pattern.** Pattern shape may evolve khi variant thứ 3 được introduce.

--- a/workspaces/default/platform/patterns/workspace-resolve-step0.md
+++ b/workspaces/default/platform/patterns/workspace-resolve-step0.md
@@ -1,3 +1,9 @@
+---
+type: Pattern
+title: "Pattern: workspace-resolve-step0"
+description: "Mọi slash command wiki-aware resolve active workspace trước khi làm bất cứ gì — engine invariant chống cross-workspace pollution."
+---
+
 # Pattern: workspace-resolve-step0
 
 ## Context

--- a/workspaces/default/product/briefs/agent-context-build.md
+++ b/workspaces/default/product/briefs/agent-context-build.md
@@ -1,3 +1,9 @@
+---
+type: Brief
+title: "Product Brief: Reliable Agent Inputs"
+description: "Product brief — teams có decisions/contracts/requirements nhưng agents consume inconsistently; mục tiêu là reliable agent inputs."
+---
+
 # Product Brief: Reliable Agent Inputs
 
 ## Problem

--- a/workspaces/default/requirements/agent-context-build.md
+++ b/workspaces/default/requirements/agent-context-build.md
@@ -1,3 +1,9 @@
+---
+type: Requirement
+title: "Requirement: Build Reliable Agent Inputs"
+description: "Requirement — AI tooling maintainer cần repeatable task context cho product/design task, không chỉ coding-rule snippets."
+---
+
 # Requirement: Build Reliable Agent Inputs
 
 ## Actor

--- a/workspaces/default/runbooks/config-resolution-failure.md
+++ b/workspaces/default/runbooks/config-resolution-failure.md
@@ -1,3 +1,9 @@
+---
+type: Runbook
+title: "Runbook: Config Resolution Failure"
+description: "Config/workspace/knowledge_root không resolve được — các command active-workspace fail."
+---
+
 # Runbook: Config Resolution Failure
 
 ## Symptom

--- a/workspaces/default/runbooks/context-artifact-generation-failure.md
+++ b/workspaces/default/runbooks/context-artifact-generation-failure.md
@@ -1,3 +1,9 @@
+---
+type: Runbook
+title: "Runbook: Context Artifact Generation Failure"
+description: "contextd context fail / blocking gaps / omit contracts — artifact không satisfy contextd_task_context.v1."
+---
+
 # Runbook: Context Artifact Generation Failure
 
 ## Symptom

--- a/workspaces/default/runbooks/context-quality-degradation.md
+++ b/workspaces/default/runbooks/context-quality-degradation.md
@@ -1,3 +1,9 @@
+---
+type: Runbook
+title: "Runbook: Context Quality Degradation"
+description: "Context thành công nhưng agent nhận context yếu/sai — wrong docs, over-budget, stale current-task, adapter drift."
+---
+
 # Runbook: Context Quality Degradation
 
 ## Symptom

--- a/workspaces/default/runbooks/golden-eval-regression.md
+++ b/workspaces/default/runbooks/golden-eval-regression.md
@@ -1,3 +1,9 @@
+---
+type: Runbook
+title: "Runbook: Golden Eval Regression"
+description: "contextd eval --golden exit non-zero — fixture report missing/forbidden docs, category, gap, policy mismatch."
+---
+
 # Runbook: Golden Eval Regression
 
 ## Symptoms

--- a/workspaces/default/runbooks/materialized-context-pack-stale.md
+++ b/workspaces/default/runbooks/materialized-context-pack-stale.md
@@ -1,3 +1,9 @@
+---
+type: Runbook
+title: "Runbook: Materialized Context Pack Stale"
+description: ".contextd/context/current-task.* stale sau khi contracts, patterns, workspace profile hoặc active packs đổi."
+---
+
 # Runbook: Materialized Context Pack Stale
 
 ## Symptom

--- a/workspaces/default/runbooks/policy-check-failure.md
+++ b/workspaces/default/runbooks/policy-check-failure.md
@@ -1,3 +1,9 @@
+---
+type: Runbook
+title: "Runbook: Policy Check Failure"
+description: "contextd policy-check exit 1/2 — governance_report status error hoặc warning."
+---
+
 # Runbook: Policy Check Failure
 
 ## Symptoms

--- a/workspaces/default/runbooks/release-manifest-build-failure.md
+++ b/workspaces/default/runbooks/release-manifest-build-failure.md
@@ -1,3 +1,9 @@
+---
+type: Runbook
+title: "Runbook: Release Manifest Build Failure"
+description: "Release packaging, manifest generation, PyInstaller smoke hoặc editable install version detection fail từ clean checkout."
+---
+
 # Runbook: Release Manifest Build Failure
 
 ## Symptom

--- a/workspaces/default/runbooks/runtime-adapter-drift.md
+++ b/workspaces/default/runbooks/runtime-adapter-drift.md
@@ -1,3 +1,9 @@
+---
+type: Runbook
+title: "Runbook: Runtime Adapter Drift"
+description: "Claude, Codex, Cursor hoặc markdown exports disagree về workspace resolution, context format, legacy paths."
+---
+
 # Runbook: Runtime Adapter Drift
 
 ## Symptom

--- a/workspaces/default/runbooks/team-sync-knowledge-root-failure.md
+++ b/workspaces/default/runbooks/team-sync-knowledge-root-failure.md
@@ -1,3 +1,9 @@
+---
+type: Runbook
+title: "Runbook: Team Sync Knowledge Root Failure"
+description: "/contextd-team-sync pull|push|status không tìm được team knowledge repo — wrong remote, pull/push conflicts."
+---
+
 # Runbook: Team Sync Knowledge Root Failure
 
 ## Symptom

--- a/workspaces/default/runbooks/workspace-switch-mismatch.md
+++ b/workspaces/default/runbooks/workspace-switch-mismatch.md
@@ -1,3 +1,9 @@
+---
+type: Runbook
+title: "Runbook: Workspace Switch Mismatch"
+description: "Sau switch-workspace, commands vẫn dùng workspace cũ — packs sai, context tham chiếu docs sai scope."
+---
+
 # Runbook: Workspace Switch Mismatch
 
 ## Symptom


### PR DESCRIPTION
## Summary
- Adopt [OKF v0.2](https://github.com/GoogleCloudPlatform/knowledge-catalog/blob/main/okf/SPEC.md) as the metadata layer for wiki concept files: required `type` + recommended `title`/`description` in YAML frontmatter
- `scripts/lint-wiki.py`: add OKF conformance checks (frontmatter parseable, `type` non-empty, type ∈ known set, `status` enum, `sources[].id` ↔ footnote `[^id]`) — all warn-only (exit 2 class), stdlib-only subset YAML parser; skips index/config files, `evidence/` runtime artifacts
- 31 concept files in `workspaces/default` converted: 7 patterns, 8 contracts, 3 ADRs, 11 runbooks, design system, product brief, requirement
- 9 concept templates updated with OKF frontmatter placeholders (pattern, adr, runbook, service, tool-recipe, tool-spec, 3 evidence QA templates)
- Type set extended with `Brief`, `Requirement`, `Design` (lint warning only for unknown types)
- `docs/wiki-reference.md`: documents type set, field mapping, actor convention, enforcement rules
- `scripts/test_lint_wiki.py`: 7 OKF tests (incl. evidence-runtime-artifact exclusion)

## Test plan
- [x] `python3 scripts/test_lint_wiki.py` → ALL TESTS PASSED
- [x] `python3 scripts/lint-wiki.py --all-workspaces --wiki-root .` → broken=0, orphaned=0, okf=0
- [x] /evidence-qa end-to-end on an evidence set to confirm QA templates with frontmatter don't break the pipeline (verified 2026-08-11 — fixture 2026-08-11-paste-okf-qa-templates: ingest → analyze → qa → qa_done; rendered batch-1/batch-2-answers.md parse OK; lint okf=0; tests pass)

from therealTINHTUTE with love ❤️