### PR TITLE
fix(okf): align sources validation with OKF v0.2 semantics

### DIFF
--- a/docs/wiki-reference.md
+++ b/docs/wiki-reference.md
@@ -125,10 +125,10 @@ Concept files trong workspace theo [OKF v0.2](https://github.com/GoogleCloudPlat
 
 - `status` ∈ `draft | stable | deprecated` (absent ⇒ `stable`). Tool-spec dùng lifecycle riêng (`draft|specced|building|done|shelved` — pack constraint, không đổi).
 - Provenance: `generated: { by: <actor>, at: <ISO> }`, `verified: [{ by, at }]`, actor convention `human:<id>` / `process:<id>` / `<agent>/<version>`.
-- Per-claim attribution: footnote `[^id]` trong body, `id` join vào `sources[].id`.
+- Per-claim attribution: footnote `[^id]` trong body, `id` join vào `sources[].id`; `resource` bắt buộc mỗi entry, `id` optional (entry chỉ có `resource`, hoặc id không được cite trong body, đều hợp lệ).
 - Consumers KHÔNG reject unknown keys/types — OKF "tolerate unknown" (lint chỉ warning).
 
-**Enforcement**: `scripts/lint-wiki.py` check frontmatter parseable, `type` non-empty, type ∈ set, `status` ∈ enum, `sources[].id` có footnote tương ứng — tất cả warning, **exit 0 mặc định** (CI-friendly; `--strict` → exit 2 nếu muốn warnings-as-errors). File ngoài concept (index/config) và `.claude/**` (harness schema riêng) không bị check.
+**Enforcement**: `scripts/lint-wiki.py` check frontmatter parseable, `type` non-empty, type ∈ set, `status` ∈ enum, mỗi `sources[]` entry có `resource`, footnote `[^id]` khớp `sources[].id` (id không cite trong body là hợp lệ) — tất cả warning, **exit 0 mặc định** (CI-friendly; `--strict` → exit 2 nếu muốn warnings-as-errors). File ngoài concept (index/config) và `.claude/**` (harness schema riêng) không bị check.
 
 ## Detailed References
 

--- a/scripts/lint-wiki.py
+++ b/scripts/lint-wiki.py
@@ -24,8 +24,9 @@ Checks per workspace:
   is referenced by patterns-index.md (warn-only orphan).
 - OKF v0.2 conformance (warn-only) on every concept .md file:
   frontmatter parseable, `type` present & non-empty, type in known set,
-  `status` in {draft, stable, deprecated}, `sources[].id` referenced by a
-  body footnote `[^id]`. Index/config files (README.md, INDEX.md,
+  `status` in {draft, stable, deprecated}, each `sources[]` entry has a
+  `resource`, and every body footnote `[^id]` matches a `sources[].id`
+  (an uncited id is valid). Index/config files (README.md, INDEX.md,
   _index.md, patterns-index.md, workspace.md, knowledge-map.md) are skipped.
 
 Output:
@@ -249,16 +250,28 @@ def check_okf_file(file: Path, findings: list[dict]) -> None:
         })
     sources = fm.get("sources")
     if isinstance(sources, list):
-        footnote_ids = set(FOOTNOTE_RE.findall(body))
+        # OKF v0.2: `resource` is required per source entry; `id` is optional
+        # and only the join key for per-claim footnotes — an uncited id is valid.
+        source_ids: set[str] = set()
         for src in sources:
             if not isinstance(src, dict):
                 continue
-            sid = src.get("id")
-            if isinstance(sid, str) and sid not in footnote_ids:
+            resource = src.get("resource")
+            if not isinstance(resource, str) or not resource.strip():
                 findings.append({
                     "file": str(file),
-                    "kind": "okf_source_id_unreferenced",
-                    "detail": f"sources[].id {sid!r} has no body footnote [^{sid}]",
+                    "kind": "okf_source_missing_resource",
+                    "detail": "sources[] entry has no non-empty `resource`",
+                })
+            sid = src.get("id")
+            if isinstance(sid, str):
+                source_ids.add(sid)
+        for fid in set(FOOTNOTE_RE.findall(body)):
+            if fid not in source_ids:
+                findings.append({
+                    "file": str(file),
+                    "kind": "okf_footnote_unresolved",
+                    "detail": f"body footnote [^{fid}] has no matching sources[].id",
                 })
 
 

--- a/scripts/test_lint_wiki.py
+++ b/scripts/test_lint_wiki.py
@@ -159,7 +159,7 @@ def test_okf_unknown_type_and_bad_status() -> None:
         assert rc == 0, rc
 
 
-def test_okf_source_id_unreferenced() -> None:
+def test_okf_sources_semantics() -> None:
     with tempfile.TemporaryDirectory() as td:
         root = Path(td)
         ws = root / "workspaces" / "ws"
@@ -168,14 +168,23 @@ def test_okf_source_id_unreferenced() -> None:
             "---\ntype: Contract\ntitle: T\ndescription: D\nsources:\n"
             "  - id: used-source\n    resource: https://example.com/a\n"
             "  - id: orphan-source\n    resource: https://example.com/b\n"
-            "---\n# T\n\nClaim [^used-source].\n",
+            "  - id: no-resource-source\n"
+            "  - resource: https://example.com/c\n"
+            "---\n# T\n\nClaim [^used-source] and [^ghost].\n",
             encoding="utf-8",
         )
         (ws / "workspace.md").write_text("# ws\n[c](platform/contracts/c.md)\n", encoding="utf-8")
         (ws / "patterns-index.md").write_text("# i\n[c](platform/contracts/c.md)\n", encoding="utf-8")
         rc, data, _err = run_lint(root, "ws")
         kinds = [(f["kind"], f["detail"]) for f in data["okf"]]
-        assert any("orphan-source" in d for k, d in kinds if k == "okf_source_id_unreferenced"), kinds
+        # OKF v0.2: a source id not cited in the body is valid
+        assert not any("orphan-source" in d for k, d in kinds), kinds
+        # source entry missing required `resource` -> warning
+        assert any(k == "okf_source_missing_resource" for k, d in kinds), kinds
+        # body footnote with no matching sources[].id -> warning
+        assert any("ghost" in d for k, d in kinds if k == "okf_footnote_unresolved"), kinds
+        # resource-only entry (no id) and cited source are not flagged
+        assert not any("example.com/c" in d or "used-source" in d for k, d in kinds), kinds
         assert rc == 0, rc
 
 
@@ -262,7 +271,7 @@ def main() -> int:
     test_orphan_only_exit_code()
     test_okf_missing_type_warns()
     test_okf_unknown_type_and_bad_status()
-    test_okf_source_id_unreferenced()
+    test_okf_sources_semantics()
     test_okf_conformant_clean()
     test_okf_skips_index_config_files()
     test_okf_skips_evidence_runtime_artifacts()


### PR DESCRIPTION
## Summary
Addresses the non-blocking review comment on #3 about `sources` validation.

Per OKF v0.2, `resource` is required per source entry while `id` is optional and mainly serves as the join key for per-claim attribution. The old linter warned on the wrong thing:

| Change | Before | After |
|---|---|---|
| `sources[].id` not cited in body | warning `okf_source_id_unreferenced` | valid — no warning |
| `sources[]` entry missing `resource` | no check | warning `okf_source_missing_resource` |
| body `[^foo]` with no matching `sources[].id` | no check | warning `okf_footnote_unresolved` |

Warn-only as before (exit 0 default; `--strict` → exit 2).

## Test plan
- [x] `python3 scripts/test_lint_wiki.py` → ALL TESTS PASSED
- [x] `python3 scripts/lint-wiki.py --all-workspaces --wiki-root .` → broken=0, orphaned=0, okf=0

from therealTINHTUTE with love ❤️