### PR TITLE
fix: align release version metadata

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Release version; must match pyproject.toml (for example 1.3.2)'
+        description: 'Release version; must match pyproject.toml (without the v prefix)'
         required: true
         type: string
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "contextd"
-version = "1.3.2"
+version = "1.4.0"
 description = "Build system for AI coding-agent context"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/scripts/test_contextd_runtime.py
+++ b/scripts/test_contextd_runtime.py
@@ -15,6 +15,7 @@ import hashlib
 import io
 import importlib.util
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -1364,7 +1365,16 @@ def test_thesis_hardening_docs_and_release_mapping() -> None:
     assert 'BINARY="contextd-${PLATFORM}-arm64"' not in release, release
     assert "Linux arm64 prebuilt binary is not available" in release, release
     assert "contextd-linux-arm64" not in release, release
-    assert 'version = "1.3.2"' in pyproject, pyproject
+    project_version_match = re.search(
+        r'(?m)^version\s*=\s*"([^"]+)"\s*$',
+        pyproject,
+    )
+    assert project_version_match, pyproject
+    project_version = project_version_match.group(1)
+    assert re.fullmatch(
+        r"[0-9]+\.[0-9]+\.[0-9]+(?:[.-][0-9A-Za-z.-]+)?",
+        project_version,
+    ), project_version
     for module in ("cmd_synapse", "lib.synapse_engine", "lib.frontmatter"):
         assert f"'{module}'" in spec, (module, spec)
     assert "'synapse_engine'" not in spec, "top-level lib module would create duplicate state"
@@ -1372,7 +1382,7 @@ def test_thesis_hardening_docs_and_release_mapping() -> None:
     assert "needs: [release-metadata, verify, package-source, build-binaries]" in release
     assert "python-version: ['3.10', '3.12']" in release
     actual_version = contextd_version.get_version(start_path=ROOT)
-    assert actual_version == "1.3.2", actual_version
+    assert actual_version == project_version, (actual_version, project_version)
     print("  ok thesis_hardening_docs_and_release_mapping")
 
 


### PR DESCRIPTION
  ## Implementation

  ## Summary / Context

  Align the repository metadata with the intended `1.4.0` release.

  This change:

  - Updates the canonical project version in `pyproject.toml` from `1.3.2` to `1.4.0`.
  - Removes the stale hardcoded version example from the release workflow input description.
  - Replaces the runtime test's fixed `1.3.2` assertions with checks that:
    - Read the version from `pyproject.toml`
    - Validate its SemVer-compatible format
    - Confirm runtime version resolution returns the same value

  ## Problem & Why

  The release workflow was dispatched with version `1.4.0`, but the canonical project metadata still declared `1.3.2`.

  The `release-metadata` job therefore stopped immediately with:

  ```text
  ERROR: release version 1.4.0 != pyproject version 1.3.2

  The runtime test also hardcoded 1.3.2, meaning every legitimate version bump required an additional test rewrite.

  This fix makes pyproject.toml the canonical release-version source and keeps the test focused on format and consistency rather than a specific historical version.

  ## Test Notes

  - [x] python scripts/test_lint_wiki.py
  - [x] python scripts/test_atomic_write.py
  - [x] python scripts/test_detect_repetition.py
  - [x] python scripts/lint-wiki.py --all-workspaces --wiki-root .
  - [ ] N/A (reason):

  Additional checks:

  - [x] Release metadata resolves to 1.4.0
  - [x] python3 -m scripts.cli --version returns contextd 1.4.0
  - [x] python3 scripts/test_contextd_runtime.py — 46/46 passed
  - [x] python3 scripts/test_artifact_schemas.py
  - [x] python3 scripts/check-patterns-index.py
  - [x] python3 -m compileall -q scripts
  - [x] Strict all-workspace wiki lint passed

  ## Related Issues

  Relates to the failed 1.4.0 release workflow run. No linked GitHub issue.

  ## Docs / Workflow Impact

  - [x] Updated docs because behavior/workflow changed
  - [ ] No docs update needed (reason):

  The workflow_dispatch input description now explains that the release version must match pyproject.toml and must not include the v prefix, without embedding a version example that
  becomes stale after each release.

  ## Wiki-specific checks

  - [x] Preserved workspace isolation
  - [x] No cross-workspace knowledge mixing
  - [x] Avoided duplicate docs/patterns

  No workspace knowledge, retrieval behavior, patterns, or contracts were changed.

  ## Project Spirit Check

  - [x] Change reinforces knowledge-first workflow (contracts/patterns before invention)
  - [x] Contributor experience stays simple and practical (no unnecessary complexity)
  - [x] Project voice and intent remain consistent across docs/workflows
  - [x] If trade-offs were made, rationale is stated clearly in this PR

  Trade-off rationale:

  The runtime test no longer pins one exact release number. Instead, it validates the version format and verifies that runtime resolution matches the canonical pyproject.toml value. This
  preserves release safety while removing repetitive test maintenance for future version bumps.